### PR TITLE
Cleanup nov relevant concepts

### DIFF
--- a/wm.yml
+++ b/wm.yml
@@ -11,23 +11,25 @@
         - provision_of_goods_and_services:
           - education:
             - child_friendly_learning_spaces
+            - provide_stationery
           - health:
             - anti-retroviral_treatment
             - sexual_violence_management
             - vector_control
+            - provide_delivery_kit
           - nutrition:
             - therapeutic_feeding_or_treating
-          - provide_hygiene_tool
-          - provide_delivery_kit
-          - provide_farming_tool
-          - provide_seed
-          - provide_livestock_feed
-          - provide_veterinary_service
-          - provide_stationery
-          - provide_fishing_tool
-          - provide_cash
-          - provide_food
-          - provide_veterinary_drugs_vaccines
+          - food_security:
+            - provide_farming_tool
+            - provide_seed
+            - provide_livestock_feed
+            - provide_veterinary_service
+            - provide_fishing_tool
+            - provide_cash
+            - provide_food
+            - provide_veterinary_drugs_vaccines
+          - water_sanitation_hygiene:
+            - provide_hygiene_tool
           - provide_moving_of_households
         - infrastructure
         - peacekeeping_and_security

--- a/wm.yml
+++ b/wm.yml
@@ -157,7 +157,6 @@
         - transport
         - human_displacement
         - evacuate_humanitarian_workers
-        - food_distribution
       - agriculture:
         - agricultural_production
         - planting

--- a/wm.yml
+++ b/wm.yml
@@ -27,7 +27,6 @@
             - provide_fishing_tool
             - provide_cash
             - provide_food
-            - provide_veterinary_drugs_vaccines
           - water_sanitation_hygiene:
             - provide_hygiene_tool
           - provide_moving_of_households

--- a/wm.yml
+++ b/wm.yml
@@ -40,8 +40,6 @@
           - climate
           - precipitation:
             - rainfall
-            - flooding
-            - drought
             - storm
           - temperature # temperature of ...
         - environment
@@ -68,7 +66,6 @@
         - crisis
         - economic:
           - economic_crisis
-          - poverty
         - environmental:
           - crop_failure
           - insect_infestation
@@ -78,7 +75,6 @@
             - wildfire
             - volcanic_eruption
             - drought
-            - storm
             - earthquake
           - weather_issue:
             - cold_temperature
@@ -185,7 +181,6 @@
         - death
         - injury
         - birth
-        - famine
         - basic_needs
       - access:
         - infrastructure:

--- a/wm.yml
+++ b/wm.yml
@@ -21,6 +21,8 @@
             - disease_outbreak_control
             - first_aid_basic_medical_care
             - obstetric_newborn_care
+            - psychological_support
+            - epidemiological_surveillance_system
           - nutrition:
             - therapeutic_feeding_or_treating
             - malnutrition_screening
@@ -33,6 +35,7 @@
             - provide_cash
             - provide_food
           - water_sanitation_hygiene:
+            - sanitation_services
             - provide_hygiene_tool
             - communal_washing_and_bathing
             - household_solid_waste_management
@@ -42,6 +45,10 @@
             - rental_subsidies
           - protection:
             - policing_services
+            - child_rights
+            - mine_risk_education
+            - family_reunification
+            - legal_aid
           - provide_moving_of_households
         - infrastructure
         - peacekeeping_and_security
@@ -68,6 +75,7 @@
           - fossil_fuels
           - soil
           - water_management # CauseEx
+          - pasture
         - pollution:
           - air_pollution
           - land_pollution
@@ -178,6 +186,7 @@
         - irrigation
         - pesticide
         - crop
+        - crop_production
         - livestock_production
         - pest
       - health_and_life:

--- a/wm.yml
+++ b/wm.yml
@@ -190,7 +190,6 @@
           - animal_disease
         - treatment:
           - health_treatment
-          - health_intervention
         - death
         - injury
         - birth

--- a/wm.yml
+++ b/wm.yml
@@ -12,13 +12,18 @@
           - education:
             - child_friendly_learning_spaces
             - provide_stationery
+            - school_feeding
           - health:
             - anti-retroviral_treatment
             - sexual_violence_management
             - vector_control
             - provide_delivery_kit
+            - disease_outbreak_control
+            - first_aid_basic_medical_care
+            - obstetric_newborn_care
           - nutrition:
             - therapeutic_feeding_or_treating
+            - malnutrition_screening
           - food_security:
             - provide_farming_tool
             - provide_seed
@@ -29,6 +34,14 @@
             - provide_food
           - water_sanitation_hygiene:
             - provide_hygiene_tool
+            - communal_washing_and_bathing
+            - household_solid_waste_management
+          - emergency_shelter:
+            - provide_tent_shelter
+            - construction_of_prefabricated_buildings
+            - rental_subsidies
+          - protection:
+            - policing_services
           - provide_moving_of_households
         - infrastructure
         - peacekeeping_and_security

--- a/wm_metadata.yml
+++ b/wm_metadata.yml
@@ -190,17 +190,6 @@
               polarity: 1
             - OntologyNode:
               examples:
-              - flood
-              - flash flood
-              name: flooding
-              polarity: 1
-            - OntologyNode:
-              examples:
-              - drought
-              name: drought
-              polarity: 1
-            - OntologyNode:
-              examples:
               - storm
               - seasonal monsoon
               name: storm
@@ -361,11 +350,6 @@
             - financial crisis
             name: economic_crisis
             polarity: 1
-          - OntologyNode:
-            examples:
-            - poverty
-            name: poverty
-            polarity: 1
         - environmental:
           - OntologyNode:
             examples:
@@ -403,11 +387,6 @@
               examples:
               - drought
               name: drought
-              polarity: 1
-            - OntologyNode:
-              examples:
-              - storm
-              name: storm
               polarity: 1
             - OntologyNode:
               examples:
@@ -1130,11 +1109,6 @@
           examples:
           - birth
           name: birth
-          polarity: 1
-        - OntologyNode:
-          examples:
-          - famine
-          name: famine
           polarity: 1
         - OntologyNode:
           examples:

--- a/wm_metadata.yml
+++ b/wm_metadata.yml
@@ -72,6 +72,7 @@
               - disease management
               - epidemic prevention
               - outbreak control
+              - disease prevention
               name: disease_outbreak_control
               polarity: 1
             - OntologyNode:
@@ -79,6 +80,9 @@
               - first aid
               - medical care
               - health care
+              - health services
+              - health intervention
+              - medical crisis response
               name: first_aid_basic_medical_care
               polarity: 1
             - OntologyNode:
@@ -1170,16 +1174,6 @@
             - medical therapy
             - theraputic treatment
             name: health_treatment
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - vaccine
-            - vaccination
-            - disease prevention
-            - health services
-            - health intervention
-            - medical crisis response
-            name: health_intervention
             polarity: 1
         - OntologyNode:
           examples:

--- a/wm_metadata.yml
+++ b/wm_metadata.yml
@@ -91,6 +91,24 @@
               - newborn care
               name: obstetric_newborn_care
               polarity: 1
+            - OntologyNode:
+              examples:
+              - psychological support
+              - psychosocial support services
+              - psychosocial services
+              - social services
+              name: psychological_support
+              polarity: 1
+            - OntologyNode:
+              examples:
+              - epidemiological surveillance
+              - disease surveillance
+              - awd surveillance
+              - meningitis surveillance
+              - measles surveillance
+              - cholera surveillance
+              name: epidemiological_surveillance_system
+              polarity: 1
           - nutrition:
             - OntologyNode:
               examples:
@@ -162,6 +180,15 @@
           - water_sanitation_hygiene:
             - OntologyNode:
               examples:
+              - wash services
+              - sanitation services
+              - hygiene services
+              - wash assistance
+              - wash interventions
+              name: sanitation_services
+              polarity: 1
+            - OntologyNode:
+              examples:
               - provide hygiene tool
               name: provide_hygiene_tool
               polarity: 1
@@ -211,6 +238,31 @@
               examples:
               - policing
               name: policing_services
+              polarity: 1
+            - OntologyNode:
+              examples:
+              - child protection services
+              name: child_rights
+              polarity: 1
+            - OntologyNode:
+              examples:
+              - mine risk education
+              name: mine_risk_education
+              polarity: 1
+            - OntologyNode:
+              examples:
+              - family separation
+              - child separation
+              - children separation
+              - reunification services
+              - family reunification
+              name: family_reunification
+              polarity: 1
+            - OntologyNode:
+              examples:
+              - legal aid
+              - legal assistance
+              name: legal_aid
               polarity: 1
           - OntologyNode:
             examples:
@@ -395,6 +447,15 @@
             examples:
             - water management
             name: water_management # CauseEx
+            polarity: 1
+          - OntologyNode:
+            examples:
+            - pastoral conditions
+            - pasture conditions
+            - rangeland conditions
+            - vegetation conditions
+            - grazing conditions
+            name: pasture
             polarity: 1
         - pollution:
           - OntologyNode:
@@ -1095,6 +1156,26 @@
           - white maize
           - white sorghum
           name: crop
+          polarity: 1
+        - OntologyNode:
+          examples:
+          - cereal production
+          - rice production
+          - grain production
+          - soybean production
+          - sorghum production
+          - maize production
+          - groundnut production
+          - bean production
+          - vegetable production
+          - sesame production
+          - seed production
+          - cropping
+          - coffee production
+          - meher production
+          - pepper production
+          - millet production
+          name: crop_production
           polarity: 1
         - OntologyNode:
           examples:

--- a/wm_metadata.yml
+++ b/wm_metadata.yml
@@ -88,6 +88,8 @@
             - OntologyNode:
               examples:
               - provide veterinary service
+              - provide veterinary drugs
+              - animal vaccination
               name: provide_veterinary_service
               polarity: 1
             - OntologyNode:
@@ -111,12 +113,6 @@
               - deliver food
               - humanitarian food drop
               name: provide_food
-              polarity: 1
-            - OntologyNode:
-              examples:
-              - provide veterinary drugs
-              - animal vaccination
-              name: provide_veterinary_drugs_vaccines
               polarity: 1
           - water_sanitation_hygiene:
             - OntologyNode:

--- a/wm_metadata.yml
+++ b/wm_metadata.yml
@@ -36,6 +36,11 @@
               - provided paper
               name: provide_stationery
               polarity: 1
+            - OntologyNode:
+              examples:
+              - school feeding
+              name: school_feeding
+              polarity: 1
           - health:
             - OntologyNode:
               examples:
@@ -60,6 +65,28 @@
               - provide delivery kit
               name: provide_delivery_kit
               polarity: 1
+            - OntologyNode:
+              examples:
+              - vaccination
+              - disease control
+              - disease management
+              - epidemic prevention
+              - outbreak control
+              name: disease_outbreak_control
+              polarity: 1
+            - OntologyNode:
+              examples:
+              - first aid
+              - medical care
+              - health care
+              name: first_aid_basic_medical_care
+              polarity: 1
+            - OntologyNode:
+              examples:
+              - obstetric care
+              - newborn care
+              name: obstetric_newborn_care
+              polarity: 1
           - nutrition:
             - OntologyNode:
               examples:
@@ -67,6 +94,19 @@
               - therapeutic treating
               - nutritional assistance
               name: therapeutic_feeding_or_treating
+              polarity: 1
+            - OntologyNode:
+              examples:
+              - malnutrition screening
+              - malnutrition assessment
+              - nutrition assessment
+              - screening of acute malnutrition
+              - management of acute malnutrition
+              - nutritional assessment
+              - nutrition screening
+              - nutritional surveillance
+              - screening for malnutrition
+              name: malnutrition_screening
               polarity: 1
           - food_security:
             - OntologyNode:
@@ -121,6 +161,53 @@
               - provide hygiene tool
               name: provide_hygiene_tool
               polarity: 1
+            - OntologyNode:
+              examples:
+              - communal shower
+              - emergency laundry
+              - emergency handwashing
+              - communal sanitation
+              - communal wash
+              name: communal_washing_and_bathing
+              polarity: 1
+            - OntologyNode:
+              examples:
+              - waste disposal
+              - waste treatment
+              name: household_solid_waste_management
+              polarity: 1
+          - emergency_shelter:
+            - OntologyNode:
+              examples:
+              - delivery of tents
+              - provision of tents
+              - provision of shelter
+              - provide tents
+              - provide shelter
+              - distribute tents
+              name: provide_tent_shelter
+              polarity: 1
+            - OntologyNode:
+              examples:
+              - prefab construction
+              - prefabricated housing construction
+              - modular construction
+              - modular building construction
+              name: construction_of_prefabricated_buildings
+              polarity: 1
+            - OntologyNode:
+              examples:
+              - housing subsidies
+              - rental subsidies
+              - housing assistance
+              name: rental_subsidies
+              polarity: 1
+          - protection:
+            - OntologyNode:
+              examples:
+              - policing
+              name: policing_services
+              polarity: 1
           - OntologyNode:
             examples:
             - provide moving of households
@@ -139,6 +226,13 @@
           - construction
           - improving infrastructure
           - repairing
+          - mobile hospital deployment
+          - rehabilitate road
+          - maintain road
+          - repair road
+          - road rehabilitation
+          - road maintenance
+          - road repair
           polarity: 1
         - OntologyNode:
           pattern:
@@ -153,6 +247,10 @@
           - ceasefire
           - demobilization
           - mediation
+          - conflict resolution
+          - conflict mediation
+          - disarmament
+          - reintegration
           polarity: 1
         - institutional_support:
           - protection:

--- a/wm_metadata.yml
+++ b/wm_metadata.yml
@@ -112,6 +112,7 @@
               - food aid
               - deliver food
               - humanitarian food drop
+              - distribution of food
               name: provide_food
               polarity: 1
           - water_sanitation_hygiene:
@@ -889,11 +890,6 @@
           examples:
           - evacuate humanitarian workers
           name: evacuate_humanitarian_workers
-          polarity: 1
-        - OntologyNode:
-          examples:
-          - distribution of food
-          name: food_distribution
           polarity: 1
       - agriculture:
         - OntologyNode:

--- a/wm_metadata.yml
+++ b/wm_metadata.yml
@@ -31,6 +31,11 @@
               - provide schools for children
               name: child_friendly_learning_spaces
               polarity: 1
+            - OntologyNode:
+              examples:
+              - provided paper
+              name: provide_stationery
+              polarity: 1
           - health:
             - OntologyNode:
               examples:
@@ -50,6 +55,11 @@
               - disease vector control
               name: vector_control
               polarity: 1
+            - OntologyNode:
+              examples:
+              - provide delivery kit
+              name: provide_delivery_kit
+              polarity: 1
           - nutrition:
             - OntologyNode:
               examples:
@@ -58,70 +68,62 @@
               - nutritional assistance
               name: therapeutic_feeding_or_treating
               polarity: 1
-          - OntologyNode:
-            examples:
-            - provide hygiene tool
-            name: provide_hygiene_tool
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - provide delivery kit
-            name: provide_delivery_kit
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - provide farming tool
-            name: provide_farming_tool
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - provide seed
-            name: provide_seed
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - provide livestock feed
-            - provided with fodder
-            name: provide_livestock_feed
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - provide veterinary service
-            name: provide_veterinary_service
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - provided paper
-            name: provide_stationery
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - provide fishing nets
-            name: provide_fishing_tool
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - provide cash
-            - provide money
-            - provide loan
-            - monetary injection
-            name: provide_cash
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - provide food
-            - food assistance
-            - food aid
-            - deliver food
-            - humanitarian food drop
-            name: provide_food
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - provide veterinary drugs
-            - animal vaccination
-            name: provide_veterinary_drugs_vaccines
-            polarity: 1
+          - food_security:
+            - OntologyNode:
+              examples:
+              - provide farming tool
+              name: provide_farming_tool
+              polarity: 1
+            - OntologyNode:
+              examples:
+              - provide seed
+              name: provide_seed
+              polarity: 1
+            - OntologyNode:
+              examples:
+              - provide livestock feed
+              - provided with fodder
+              name: provide_livestock_feed
+              polarity: 1
+            - OntologyNode:
+              examples:
+              - provide veterinary service
+              name: provide_veterinary_service
+              polarity: 1
+            - OntologyNode:
+              examples:
+              - provide fishing nets
+              name: provide_fishing_tool
+              polarity: 1
+            - OntologyNode:
+              examples:
+              - provide cash
+              - provide money
+              - provide loan
+              - monetary injection
+              name: provide_cash
+              polarity: 1
+            - OntologyNode:
+              examples:
+              - provide food
+              - food assistance
+              - food aid
+              - deliver food
+              - humanitarian food drop
+              name: provide_food
+              polarity: 1
+            - OntologyNode:
+              examples:
+              - provide veterinary drugs
+              - animal vaccination
+              name: provide_veterinary_drugs_vaccines
+              polarity: 1
+          - water_sanitation_hygiene:
+            - OntologyNode:
+              examples:
+              - provide hygiene tool
+              name: provide_hygiene_tool
+              polarity: 1
           - OntologyNode:
             examples:
             - provide moving of households


### PR DESCRIPTION
@BeckySharp , as the commits say, these are mostly: (1) remove duplicate concepts like `famine`, `drought`, etc. (2) organize some existing interventions (e.g. put `provide_delivery_kit` under `health`, (3) add some intervention concepts (e.g. `sanitation_services`),, (4) add a few non-intervention concepts (e.g. `pasture`)

To note: 
* `provide_veterinary_drugs_vaccines` is folded into `provide_veterinary_services`
* fold `food_distribution` (which looks to be an Intervention event) into the `provide_food` intervention type
* fold `health_intervention` (which wasn't under the intervention branch) into `disease_outbreak_control` and `first_aid_basic_medical_care` (which are new concepts introduced under the intervention branch)
