### PR TITLE
More edits

### DIFF
--- a/wm_with_flattened_interventions.yml
+++ b/wm_with_flattened_interventions.yml
@@ -318,7 +318,6 @@
         - food_nonaccess
         - food_instability
     - entity:
-      - land
       - geo-location
       - organization
       - government_entity

--- a/wm_with_flattened_interventions.yml
+++ b/wm_with_flattened_interventions.yml
@@ -167,8 +167,6 @@
             #- wages
             #- high unemployment
             #- underemployment
-            - foraging
-            - hunting
             - farming
           - currency
           - cross_border_trade:
@@ -271,6 +269,9 @@
         - plant_disease:
           - pest_infestation
         - livestock_disease
+      - wild_food_sources:
+        - foraging_wild_foods
+        - hunting
       - health_and_life:
         - living_condition:
           - food_safety
@@ -279,6 +280,8 @@
         - nutrition:
           - food_intake
           - food_diversity
+          - food_preparation
+          - food_preference
           - malnutrition
           - breast_feeding
         - biometrics
@@ -309,9 +312,11 @@
       - trend
       - food_security:
         - food_availability
+        - food_production
         - food_utilization
         - food_access
         - food_stability
+        - food_reserves
       - food_insecurity:
         - food_unavailability
         - food_nonutilization

--- a/wm_with_flattened_interventions.yml
+++ b/wm_with_flattened_interventions.yml
@@ -316,7 +316,6 @@
         - food_utilization
         - food_access
         - food_stability
-        - food_reserves
       - food_insecurity:
         - food_unavailability
         - food_nonutilization

--- a/wm_with_flattened_interventions.yml
+++ b/wm_with_flattened_interventions.yml
@@ -121,7 +121,6 @@
         - resource_management
         - forestry
         - natural_resources:
-          - land
           - water_bodies
           - land_availability
           - fossil_fuels
@@ -319,6 +318,7 @@
         - food_nonaccess
         - food_instability
     - entity:
+      - land
       - geo-location
       - organization
       - government_entity

--- a/wm_with_flattened_interventions_metadata.yml
+++ b/wm_with_flattened_interventions_metadata.yml
@@ -2046,21 +2046,6 @@
     - entity:
       - OntologyNode:
         examples:
-          - area
-          - land
-          - mountain
-          - mt
-          - wetland
-          - sand
-          - flood plains
-          - greenbelt
-          - agricultural land
-          - arable land
-          - cultivated area
-        name: land
-        polarity: 1
-      - OntologyNode:
-        examples:
         - geographic location
         name: geo-location
         take_args: 0

--- a/wm_with_flattened_interventions_metadata.yml
+++ b/wm_with_flattened_interventions_metadata.yml
@@ -1125,6 +1125,10 @@
               - food stocks
               - food reserves
               - grain storage
+              - food reserves
+              - grain reserves
+              - food emergency reserves
+              - price stabilization reserves
               name: food_stocks
               polarity: 1
           - OntologyNode:
@@ -2032,15 +2036,6 @@
           - food stability
           name: food_stability
           opposite: wm/concept/causal_factor/condition/food_insecurity/food_instability
-          polarity: 1
-        - OntologyNode:
-          examples:
-            - food reserves
-            - grain reserves
-            - food stocks
-            - food emergency reserves
-            - price stabilization reserves
-          name: food_reserves
           polarity: 1
       - food_insecurity:
         - OntologyNode:

--- a/wm_with_flattened_interventions_metadata.yml
+++ b/wm_with_flattened_interventions_metadata.yml
@@ -676,21 +676,6 @@
         - natural_resources:
           - OntologyNode:
             examples:
-            - area
-            - land
-            - mountain
-            - mt
-            - wetland
-            - sand
-            - flood plains
-            - greenbelt
-            - agricultural land
-            - arable land
-            - cultivated area
-            name: land
-            polarity: 1
-          - OntologyNode:
-            examples:
             - water
             - sea
             - river
@@ -1407,19 +1392,19 @@
             polarity: 1
         - conflict:
           - OntologyNode:
-          examples:
-          - political tension
-          - political tensions
-          - adversity
-          - political instability
-          - stress
-          - distress
-          - challenge
-          - hardship
-          - burden
-          - threatening
-          name: tension
-          polarity: 1
+            examples:
+            - political tension
+            - political tensions
+            - adversity
+            - political instability
+            - stress
+            - distress
+            - challenge
+            - hardship
+            - burden
+            - threatening
+            name: tension
+            polarity: 1
           - OntologyNode:
             examples:
             - conflict
@@ -1766,6 +1751,8 @@
           - OntologyNode:
             examples:
             - breast feeding
+            - breastfeeding
+            - breastfed
             name: breast_feeding
             polarity: 1
         - OntologyNode:
@@ -2057,6 +2044,21 @@
           opposite: wm/concept/causal_factor/condition/food_security/food_stability
           polarity: -1
     - entity:
+      - OntologyNode:
+        examples:
+          - area
+          - land
+          - mountain
+          - mt
+          - wetland
+          - sand
+          - flood plains
+          - greenbelt
+          - agricultural land
+          - arable land
+          - cultivated area
+        name: land
+        polarity: 1
       - OntologyNode:
         examples:
         - geographic location

--- a/wm_with_flattened_interventions_metadata.yml
+++ b/wm_with_flattened_interventions_metadata.yml
@@ -871,16 +871,6 @@
             #- underemployment
             - OntologyNode:
               examples:
-              - foraging
-              name: foraging
-              polarity: 1
-            - OntologyNode:
-              examples:
-              - hunting
-              name: hunting
-              polarity: 1
-            - OntologyNode:
-              examples:
               - farming
               name: farming
               polarity: 1
@@ -1700,6 +1690,20 @@
           - livestock diseases
           name: livestock_disease
           polarity: 1
+      - wild_food_sources:
+        - OntologyNode:
+          examples:
+            - gather gathering wild foods
+            - forage
+            - foraging
+          name: foraging_wild_foods
+          polarity: 1
+        - OntologyNode:
+          examples:
+            - hunting
+            - trapping
+          name: hunting
+          polarity: 1
       - health_and_life:
         - living_condition:
           - OntologyNode:
@@ -1736,6 +1740,21 @@
             - nutrition
             - nutritional security
             name: food_diversity
+            polarity: 1
+          - OntologyNode:
+            examples:
+              - food preparation
+              - cooking
+              - meal preparation
+            name: food_preparation
+            polarity: 1
+          - OntologyNode:
+            examples:
+              - food preference
+              - seed preference
+              - dietary preferences
+              - food taste choice
+            name: food_preference
             polarity: 1
           - OntologyNode:
             examples:
@@ -1991,6 +2010,12 @@
           polarity: 1
         - OntologyNode:
           examples:
+            - food production
+            - producing food
+          name: food_production
+          polarity: 1
+        - OntologyNode:
+          examples:
           - food utilization
           - consumption of enough food
           name: food_utilization
@@ -2007,6 +2032,15 @@
           - food stability
           name: food_stability
           opposite: wm/concept/causal_factor/condition/food_insecurity/food_instability
+          polarity: 1
+        - OntologyNode:
+          examples:
+            - food reserves
+            - grain reserves
+            - food stocks
+            - food emergency reserves
+            - price stabilization reserves
+          name: food_reserves
           polarity: 1
       - food_insecurity:
         - OntologyNode:


### PR DESCRIPTION
Summary of changes:
 - fixed indentation issues with `tension` node
 - removed the `land` node for the reasons mentioned, but we can also put it in entity if ppl have big feelings about it
 - added some examples to breastfeeding node
 - addressed the recent email thread from Lynette/Alli (see below)

> L: No node “production” in the ontology (I assume this is “food production”). I think we need to add such a node – right now, it seems to be mapped to “food utilization” but I think it needs to be a sister node to food_utilization and food_availability, under food_security.  

Added.

> L: Food_reserves is missing – there are very few occurrences in this corpus, but we do see “grain reserve” – are “reserves” a kind of intervention? Or perhaps under “food_supply”? 

These seem sufficiently distinct and the reserves seem important, so I added a node. 

> L: Wild food – we do have “hunting” under livelihood, but this isn’t livelihood, it has to do with food resources (or food sources).  Maybe add a new sister node to agriculture – “wild_food_sources” and under that “hunting” and “wild foods”?  I did find a sentence re insecurity limits gathering of wild foods.

foraging was there, but I agree with you about the location, also Alli seems to agree too.  I moved foraging and hunting to where you suggested

> L: Food_preference – no good examples (I found “seed preference”).  Maybe put this as a sister node to food_diversity, under nutrition?

added

> L:	Food_preparation – missing; maybe also a sister node to food_diversity, under nutrition?  -- not sure how much would get extracted; synonym would be cooking

added

> L: Food_storage – found nothing (no key words, also looked for “preservation”).  Mintewab’s graph has it under “food_utilization” which seems reasonable, but right now, food utilization doesn’t have any children. We could put under “nutrition” along with food_preference and food_preparation.

I think maybe it makes sense to have it with food reserves? I added it as an example, but we can def make a node…. If so, i’d like to know what the differences are so we can properly “specify” the examples in the nodes for grounding.

> A: There was supposed to be a concept for 'food_intake' that I am not seeing - this should be under nutrition/ was broadly suggested under the 'utilization' concept. 

already there, thanks @chanys !