### PR TITLE
fixed typo

### DIFF
--- a/wm_flat_metadata.yml
+++ b/wm_flat_metadata.yml
@@ -74,7 +74,7 @@
                   examples:
                   - water pumps
                   - treadle
-                  - electric oump
+                  - electric pump
                   - small scale irrigation pump
                   name: pumps
                   polarity: 1


### PR DESCRIPTION
There was a typo in the exemplars for `pumps` in the flat ontology. Changed `electric oump` -> `electric pump`