### PR TITLE
add examples, new node, fix regex word boundary

### DIFF
--- a/CompositionalOntology_v2.1.yml
+++ b/CompositionalOntology_v2.1.yml
@@ -241,6 +241,7 @@
     - nonutilization
     - preference
     - price_or_cost
+    - quantity
     - security
     - stability
     - unavailability

--- a/CompositionalOntology_v2.1.yml
+++ b/CompositionalOntology_v2.1.yml
@@ -241,7 +241,6 @@
     - nonutilization
     - preference
     - price_or_cost
-    - quantity
     - security
     - stability
     - unavailability

--- a/CompositionalOntology_v2.1_metadata.yml
+++ b/CompositionalOntology_v2.1_metadata.yml
@@ -265,6 +265,8 @@
         examples:
         - finance
         - loan
+        - funding
+        - financial support
         name: finance
         polarity: 1
       - OntologyNode:
@@ -836,7 +838,7 @@
         polarity: 1
       - OntologyNode:
         pattern:
-        - hospital
+        - \bhospital\b
         - \bclinics\b
         examples:
         - hospital
@@ -1369,6 +1371,8 @@
       - OntologyNode:
         pattern:
         - death
+        - casualty
+        - casualties
         examples:
         - death
         name: death
@@ -1561,6 +1565,15 @@
       - cost
       - price
       name: price_or_cost
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - quantity
+      - amount
+      - level
+      - measure
+      - number
+      name: quantity
       polarity: 1
     - OntologyNode:
       examples:

--- a/CompositionalOntology_v2.1_metadata.yml
+++ b/CompositionalOntology_v2.1_metadata.yml
@@ -838,7 +838,7 @@
         polarity: 1
       - OntologyNode:
         pattern:
-        - \bhospital\b
+        - \bhospitals?\b
         - \bclinics\b
         examples:
         - hospital

--- a/CompositionalOntology_v2.1_metadata.yml
+++ b/CompositionalOntology_v2.1_metadata.yml
@@ -1568,15 +1568,6 @@
       polarity: 1
     - OntologyNode:
       examples:
-      - quantity
-      - amount
-      - level
-      - measure
-      - number
-      name: quantity
-      polarity: 1
-    - OntologyNode:
-      examples:
       - security
       - safety
       name: security


### PR DESCRIPTION
This PR makes the following changes based on an evaluation of the compositional grounder:
- Adds new examples in `finance` and `death` nodes
- Adds `\b` around `hospital` regex pattern in `medical_facilities` node
- Adds new `quantity` property node