### PR TITLE
Place version information into properties files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,32 +3,54 @@ name := "Ontologies"
 
 organization := "WorldModelers"
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.11.12" // "2.12.4"
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.0.4" % "test",
-  "org.yaml" % "snakeyaml" % "1.14"
+  "org.scalatest" %% "scalatest" % "3.0.4" % Test,
+  "org.yaml"       % "snakeyaml" % "1.14"
 )
 
-mappings in (Compile, packageBin) ++= Seq(
-  file("CompositionalOntology_v2.1_metadata.yml") -> "org/clulab/wm/eidos/english/ontologies/CompositionalOntology_v2.1_metadata.yml",
-  file("wm_flat_metadata.yml") -> "org/clulab/wm/eidos/english/ontologies/wm_flat_metadata.yml"
-)
-
-sourceGenerators in Compile += Def.task {
-  import Versioner._
-  // These values need to be collected in a task in order have them forwarded to Scala functions.
-  val versioner = Versioner(git.runner.value, git.gitCurrentBranch.value, baseDirectory.value, (sourceManaged in Compile).value)
-
-  // The user should set these values.
-  val namespace = "com.github.worldModelers.ontologies"
-  val files = Seq(
+def getOntologies(): (String, String, Seq[String]) = (
+  "com.github.worldModelers.ontologies", // version package
+  "org.clulab.wm.eidos.english.ontologies", // ontology package
+  Seq(
+    // The user should set these values.
     "CompositionalOntology_v2.1_metadata.yml",
     "wm_flat_metadata.yml"
   )
+)
 
-  // This reads and codes the versions.
-  versioner.version(namespace, files)
+// This copies the files to their correct places for compilation and packaging.
+// In the meantime they can be placed where it's easy to edit them.
+mappings in (Compile, packageBin) ++= {
+  val (_, resourceNamespace, filenames) = getOntologies()
+  val basedir = resourceNamespace.replace('.', '/') + "/"
+
+  filenames.map { filename =>
+    file(filename) -> (basedir + filename)
+  }
+}
+
+lazy val versionTask = Def.task {
+  val (codeNamespace, resourceNamespace, filenames) = getOntologies()
+  val versioner = Versioner(
+    git.runner.value, git.gitCurrentBranch.value, baseDirectory.value,
+    (sourceManaged in Compile).value, (resourceManaged in Compile).value,
+    codeNamespace, resourceNamespace,
+    filenames
+  )
+
+  versioner
+}
+
+sourceGenerators in Compile += Def.task {
+  versionTask.value.versionCode()
+}.taskValue
+
+resourceGenerators in Compile += Def.task {
+  versionTask.value.versionResources()
 }.taskValue
 
 lazy val root = project in file(".")
+
+ThisBuild / Test / parallelExecution := false

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ name := "Ontologies"
 
 organization := "WorldModelers"
 
-scalaVersion := "2.11.12" // "2.12.4"
+scalaVersion := "2.12.4"
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.4" % Test,

--- a/src/test/scala/org/clulab/wm/ontologies/TestDomainOntology.scala
+++ b/src/test/scala/org/clulab/wm/ontologies/TestDomainOntology.scala
@@ -1,4 +1,4 @@
-package org.clulab.wm.eidos.system
+package org.clulab.wm.ontologies
 
 import org.clulab.linnaeus.model.graph.eidos.EidosNetwork
 import org.clulab.linnaeus.model.graph.eidos.EidosNode
@@ -80,26 +80,58 @@ class TestDomainOntology extends FlatSpec with Matchers {
     var spaces = false
 
     visitor.foreachNode { (node: EidosNode, depth: Int) =>
-      if (node.name.contains(' ')) {
-        val newPath = path.slice(0, depth) :+ node.name
+      val nodeName = Option(node.name).getOrElse("")
+
+      if (nodeName.contains(' ')) {
+        val newPath = path.slice(0, depth) :+ nodeName
         spaces = true
         error(s"Spaces: $newPath")
       }
 
       if (network.isLeaf(node)) {
-        if (!node.name.contains(' ')) { // Otherwise already printed
-          val newPath = path.slice(0, depth) :+ node.name
+        if (!nodeName.contains(' ')) { // Otherwise already printed
+          val newPath = path.slice(0, depth) :+ nodeName
           trace(newPath)
         }
       }
       else
         if (depth < path.size)
-          path(depth) = node.name
+          path(depth) = nodeName
         else
-          path = path :+ node.name
+          path = path :+ nodeName
         true
     }
     spaces
+  }
+
+  def hasUnlabeled(network: EidosNetwork): Boolean = {
+    val visitor = new network.HierarchicalGraphVisitor()
+    var path = mutable.Seq.empty[String]
+    var unlabeled = false
+
+    visitor.foreachNode { (node: EidosNode, depth: Int) =>
+      val nodeName = Option(node.name).getOrElse("")
+
+      if (nodeName.isEmpty) {
+        val newPath = path.slice(0, depth) :+ nodeName
+        unlabeled = true
+        error(s"Unlabeled: $newPath")
+      }
+
+      if (network.isLeaf(node)) {
+        if (nodeName.nonEmpty) { // Otherwise already printed
+          val newPath = path.slice(0, depth) :+ nodeName
+          trace(newPath)
+        }
+      }
+      else
+        if (depth < path.size)
+          path(depth) = nodeName
+        else
+          path = path :+ nodeName
+      true
+    }
+    unlabeled
   }
 
   def hasMissingOpposites(network: EidosNetwork): Boolean = {
@@ -153,6 +185,37 @@ class TestDomainOntology extends FlatSpec with Matchers {
     missing
   }
 
+  def hasMissingExamples(network: EidosNetwork): Boolean = {
+    val visitor = new network.HierarchicalGraphVisitor()
+    var path = mutable.Seq.empty[String]
+    var missing = false
+
+    visitor.foreachNode { (node: EidosNode, depth: Int) =>
+      val nodeName = Option(node.name).getOrElse("")
+
+      if (network.isLeaf(node)) {
+        val newPath = path.slice(0, depth) :+ nodeName
+        val examples = node.examples
+        val isMissing = /*examples.isEmpty ||*/ examples.exists { example =>
+          Option(example).isEmpty || example.isEmpty
+        }
+        if (isMissing) {
+          error(s"Missing example: $newPath")
+          missing = isMissing
+        }
+        else
+          trace(newPath)
+      }
+      else
+        if (depth < path.size)
+          path(depth) = nodeName
+        else
+          path = path :+ nodeName
+      true
+    }
+    missing
+  }
+
   def test(path: String): Unit = {
       val network = new EidosNetwork()
       val reader = new EidosReader(network)
@@ -171,12 +234,20 @@ class TestDomainOntology extends FlatSpec with Matchers {
       hasDuplicateLeaves(network) should be (false)
     }
 
+    it should "not have unlabeled nodes" in {
+      hasUnlabeled(network) should be (false)
+    }
+
     it should "not have spaces" in {
       hasSpaces(network) should be (false)
     }
 
     it should "not have missing opposites" in {
       hasMissingOpposites(network) should be (false)
+    }
+
+    it should "not have missing examples" in {
+      hasMissingExamples(network) should be (false)
     }
   }
 


### PR DESCRIPTION
This is an alternative source of the information so that access to it need not be dependent on the Scala version.