### PR TITLE
Update error handling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ libraryDependencies ++= Seq(
   "org.yaml"       % "snakeyaml" % "1.14"
 )
 
-def getOntologies(): (String, String, Seq[String]) = (
+val ontologies: (String, String, Seq[String]) = (
   "com.github.worldModelers.ontologies", // version package
   "org.clulab.wm.eidos.english.ontologies", // ontology package
   Seq(
@@ -23,7 +23,7 @@ def getOntologies(): (String, String, Seq[String]) = (
 // This copies the files to their correct places for compilation and packaging.
 // In the meantime they can be placed where it's easy to edit them.
 mappings in (Compile, packageBin) ++= {
-  val (_, resourceNamespace, filenames) = getOntologies()
+  val (_, resourceNamespace, filenames) = ontologies
   val basedir = resourceNamespace.replace('.', '/') + "/"
 
   filenames.map { filename =>
@@ -32,12 +32,13 @@ mappings in (Compile, packageBin) ++= {
 }
 
 lazy val versionTask = Def.task {
-  val (codeNamespace, resourceNamespace, filenames) = getOntologies()
+  val (codeNamespace, resourceNamespace, filenames) = ontologies
   val versioner = Versioner(
-    git.runner.value, git.gitCurrentBranch.value, baseDirectory.value,
-    (sourceManaged in Compile).value, (resourceManaged in Compile).value,
+    git.runner.value, git.gitCurrentBranch.value,
+    baseDirectory.value, (sourceManaged in Compile).value, (resourceManaged in Compile).value,
     codeNamespace, resourceNamespace,
-    filenames
+    // Turn off rethrow to complete even in the presence of an error.
+    filenames, streams.value.log, rethrow = true
   )
 
   versioner

--- a/project/Versioner.scala
+++ b/project/Versioner.scala
@@ -126,7 +126,6 @@ object Versioner {
         val zonedDateTime = ZonedDateTime.ofInstant(instant, ZoneOffset.UTC)
 
         logger.info(s"Version($file) = ($hash, $zonedDateTime)")
-        throw new Exception("Keith was here")
         (file, Version(Some((hash, zonedDateTime))))
       }
       catch {

--- a/project/Versioner.scala
+++ b/project/Versioner.scala
@@ -2,9 +2,12 @@ import java.io.File
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
-
 import sbt.IO
+import sbt.util.Logger
 
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.util.function.Supplier
 import scala.util.Try
 
 case class Version(versionOpt: Option[(String, ZonedDateTime)]) {
@@ -109,8 +112,8 @@ class Versioner(versions: Versions, codebase: File, resourcebase: File, codeName
 
 object Versioner {
 
-  protected def readVersions(gitRunner: com.typesafe.sbt.git.GitRunner, gitCurrentBranch: String, baseDirectory: File,
-      files: Seq[String]): Versions = {
+  protected def readVersions(gitRunner: com.typesafe.sbt.git.GitRunner, gitCurrentBranch: String,
+      baseDirectory: File, files: Seq[String], logger: Logger, rethrow: Boolean): Versions = {
     val versions = files.map { file =>
       val gitArgs = Seq("rev-list", "--timestamp", "-1", gitCurrentBranch, file)
       // val gitArgs = Seq("log", """--format="%at %H"""", "--max-count=1", gitCurrentBranch, file)
@@ -122,12 +125,27 @@ object Versioner {
         val instant = Instant.ofEpochSecond(integerTime)
         val zonedDateTime = ZonedDateTime.ofInstant(instant, ZoneOffset.UTC)
 
+        logger.info(s"Version($file) = ($hash, $zonedDateTime)")
+        throw new Exception("Keith was here")
         (file, Version(Some((hash, zonedDateTime))))
       }
       catch {
         case throwable: Throwable =>
-          println(s"Warning: Couldn't get version for $file.")
-          throwable.printStackTrace()
+          val supplier: Supplier[String] = new Supplier[String]() {
+            override def get(): String = {
+              val stringWriter =  new StringWriter()
+              val printWriter = new PrintWriter(stringWriter)
+
+              printWriter.println(s"The version for $file couldn't be retrieved.")
+              throwable.printStackTrace(printWriter)
+              printWriter.close
+              stringWriter.toString
+            }
+          }
+
+          logger.error(supplier)
+          if (rethrow)
+            throw throwable
           (file, Version(None))
       }
     }
@@ -135,9 +153,11 @@ object Versioner {
     Versions(versions)
   }
 
-  def apply(gitRunner: com.typesafe.sbt.git.GitRunner, gitCurrentBranch: String, baseDirectory: File,
-      codebase: File, resourcebase: File, codeNamespace: String, resourceNamespace: String, filenames: Seq[String]): Versioner = {
-    val versions = readVersions(gitRunner, gitCurrentBranch, baseDirectory, "HEAD" +: filenames)
+  def apply(gitRunner: com.typesafe.sbt.git.GitRunner, gitCurrentBranch: String,
+      baseDirectory: File, codebase: File, resourcebase: File,
+      codeNamespace: String, resourceNamespace: String,
+      filenames: Seq[String], logger: Logger, rethrow: Boolean): Versioner = {
+    val versions = readVersions(gitRunner, gitCurrentBranch, baseDirectory, "HEAD" +: filenames, logger, rethrow)
 
     new Versioner(versions, codebase, resourcebase, codeNamespace, resourceNamespace, filenames)
   }


### PR DESCRIPTION
A logger is passed to Versioner so that println needn't be used.
The stack trace is logged on exception.
The version is logged on success.
The exception is rethrown to prevent bad builds.
ontologies is changed from def to val.