### PR TITLE
Reformat ontology to support children on non-leaf nodes

### DIFF
--- a/CompositionalOntology_metadata.yml
+++ b/CompositionalOntology_metadata.yml
@@ -1,13 +1,13 @@
-OntologyNode:
+node:
     name: wm
     children:
-        - OntologyNode:
+        - node:
             name: concept
             children:
-                - OntologyNode:
+                - node:
                     name: agriculture
                     children:
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - additives
                                 - amounts
@@ -51,7 +51,7 @@ OntologyNode:
                             name: animal_feed
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - agricultural science
                                 - agriculture organization
@@ -79,10 +79,10 @@ OntologyNode:
                             name: animal_science
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             name: crop
                             children:
-                                - OntologyNode:
+                                - node:
                                     definition: A grass cultivated for the edible parts of its grain.
                                     examples:
                                         - barley
@@ -94,13 +94,13 @@ OntologyNode:
                                     name: cereals
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - crop land
                                     name: crop_land
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - cereals
                                         - crop
@@ -123,13 +123,13 @@ OntologyNode:
                                     name: crops
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - fodder
                                     name: fodder
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - maize
                                         - maize grain
@@ -139,19 +139,19 @@ OntologyNode:
                                     name: maize
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - major crops
                                     name: major_crops
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - other crops
                                     name: other_crops
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - beans
                                         - lentils
@@ -160,7 +160,7 @@ OntologyNode:
                                     name: pulses
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - red sorghum
                                         - sorghum
@@ -169,25 +169,25 @@ OntologyNode:
                                     name: sorghum
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - standing crops
                                     name: standing_crops
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - staple crops
                                     name: staple_crops
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - tree crops
                                     name: tree_crops
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - cassava
                                         - potato
@@ -196,7 +196,7 @@ OntologyNode:
                                     name: tubers
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     definition: vegetable crops and food
                                     examples:
                                         - beets
@@ -208,7 +208,7 @@ OntologyNode:
                                     name: vegetables
                                     polarity: 1
                                     semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - cheese
                                 - contract farming
@@ -232,23 +232,23 @@ OntologyNode:
                             name: dairy
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             name: disease
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - blight
                                         - crop disease
                                     name: crop_disease
                                     polarity: -1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - livestock disease
                                     name: livestock_disease
                                     polarity: -1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - chicken disease
                                         - colibacillosis
@@ -257,7 +257,7 @@ OntologyNode:
                                     name: poultry_disease
                                     polarity: 1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - veterinarian
                                         - veterinarians
@@ -273,7 +273,7 @@ OntologyNode:
                                     name: veterinary_care
                                     polarity: 1
                                     semantic type: event
-                        - OntologyNode:
+                        - node:
                             definition: Domesticated animals raised for their labor or to produce commodities such as milk, meat, eggs, fur, leather, or wool.
                             examples:
                                 - beef
@@ -298,10 +298,10 @@ OntologyNode:
                             name: livestock_nonpoultry
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             name: pest
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - few swarms
                                         - fleas
@@ -328,25 +328,25 @@ OntologyNode:
                                     name: animal_pests
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - army worm
                                     name: army_worm
                                     polarity: -1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     name: locust
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - desert locust
                                             name: desert_locust
                                             polarity: 1
                                             semantic type: entity
-                                        - OntologyNode:
+                                        - node:
                                             name: gregarious
                                             children:
-                                                - OntologyNode:
+                                                - node:
                                                     patterns:
                                                         - (hopper\s+band)|(bands?\s+of\s+hoppers)
                                                     examples:
@@ -356,7 +356,7 @@ OntologyNode:
                                                     name: hopper_band
                                                     polarity: -1
                                                     semantic type: event
-                                                - OntologyNode:
+                                                - node:
                                                     patterns:
                                                         - (locust\s+swarm)|(swarms?\s+of\s+locust)
                                                         - \bDL\b
@@ -370,16 +370,16 @@ OntologyNode:
                                                     name: locust_swarm
                                                     polarity: -1
                                                     semantic type: event
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - locust eggs
                                             name: locust_eggs
                                             polarity: -1
                                             semantic type: event
-                                        - OntologyNode:
+                                        - node:
                                             name: solitary
                                             children:
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - hopper
                                                         - immature
@@ -389,7 +389,7 @@ OntologyNode:
                                                     name: solitary_hopper
                                                     polarity: -1
                                                     semantic type: event
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - mature
                                                         - solitarious adult locust
@@ -397,10 +397,10 @@ OntologyNode:
                                                     name: solitary_locust
                                                     polarity: -1
                                                     semantic type: event
-                        - OntologyNode:
+                        - node:
                             name: poultry
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - ancestors
                                         - backyard
@@ -430,7 +430,7 @@ OntologyNode:
                                     name: backyard_poultry_farming
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - healthy birds
                                         - live birds
@@ -439,7 +439,7 @@ OntologyNode:
                                     name: bird_condition_healthy
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - affected birds
                                         - avian pathology
@@ -464,7 +464,7 @@ OntologyNode:
                                     name: bird_condition_sick
                                     polarity: -1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - broiler
                                         - broiler chickens
@@ -477,7 +477,7 @@ OntologyNode:
                                     name: broiler_chickens
                                     polarity: 1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - cock
                                         - cockerel
@@ -489,7 +489,7 @@ OntologyNode:
                                     name: cockerel
                                     polarity: 1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - DOC
                                         - babies
@@ -506,7 +506,7 @@ OntologyNode:
                                     name: day_old_chicks
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - clutch
                                         - egg clutch
@@ -525,7 +525,7 @@ OntologyNode:
                                     name: egg
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - backyard flocks
                                         - base situation
@@ -546,7 +546,7 @@ OntologyNode:
                                     name: flock_size
                                     polarity: 1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - domestic ducks
                                         - domestic fowl
@@ -572,7 +572,7 @@ OntologyNode:
                                     name: fowl
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - backyard chickens
                                         - backyard flocks
@@ -596,7 +596,7 @@ OntologyNode:
                                     name: indigenous_breeds
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - brooder
                                         - brooders
@@ -617,7 +617,7 @@ OntologyNode:
                                     name: laying_hens
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - chicken
                                         - egg
@@ -625,7 +625,7 @@ OntologyNode:
                                     name: poultry
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - commercial farms
                                         - commercial producers
@@ -649,25 +649,25 @@ OntologyNode:
                                     name: poultry_sector
                                     polarity: 1
                                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - civil liberties
                     name: civil_liberties
                     polarity: 1
                     semantic type: entity
-                - OntologyNode:
+                - node:
                     examples:
                         - civil society
                     name: civil_society
                     polarity: 1
                     semantic type: entity
-                - OntologyNode:
+                - node:
                     name: crisis_or_disaster
                     children:
-                        - OntologyNode:
+                        - node:
                             name: conflict
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - acts
                                         - armed
@@ -696,7 +696,7 @@ OntologyNode:
                                     name: armed_conflict
                                     polarity: 1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - abduction
                                         - assault
@@ -745,7 +745,7 @@ OntologyNode:
                                     name: crime
                                     polarity: -1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - alienation
                                         - anger
@@ -769,7 +769,7 @@ OntologyNode:
                                     name: discontent
                                     polarity: -1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - armed clash
                                         - armed groups
@@ -798,7 +798,7 @@ OntologyNode:
                                     name: hostility
                                     polarity: -1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - adversity
                                         - burden
@@ -821,7 +821,7 @@ OntologyNode:
                                     name: tension
                                     polarity: -1
                                     semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - alarm
                                 - alerts
@@ -839,10 +839,10 @@ OntologyNode:
                             name: early_warning
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             name: environmental
                             children:
-                                - OntologyNode:
+                                - node:
                                     definition: A prolonged shortage in the water supply.
                                     examples:
                                         - drought
@@ -851,7 +851,7 @@ OntologyNode:
                                     name: drought
                                     polarity: -1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - aftershock
                                         - earthquake
@@ -861,7 +861,7 @@ OntologyNode:
                                     name: earthquake
                                     polarity: -1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - acidification
                                         - deltas
@@ -879,7 +879,7 @@ OntologyNode:
                                     name: environmental_degradation
                                     polarity: -1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - flash flood
                                         - flood
@@ -889,7 +889,7 @@ OntologyNode:
                                     name: flood
                                     polarity: -1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - cyclones
                                         - episodes
@@ -912,7 +912,7 @@ OntologyNode:
                                     name: natural_disaster
                                     polarity: -1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - cyclone
                                         - hurricane
@@ -921,21 +921,21 @@ OntologyNode:
                                     name: storm
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - volcanic eruption
                                         - volcano
                                     name: volcanic_eruption
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - wild fire
                                         - wildfire
                                     name: wildfire
                                     polarity: -1
                                     semantic type: event
-                        - OntologyNode:
+                        - node:
                             definition: The rapid spread of disease to a large population in a short amount of time.
                             examples:
                                 - disease
@@ -945,7 +945,7 @@ OntologyNode:
                             name: epidemic
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - famine
                                 - hunger
@@ -953,7 +953,7 @@ OntologyNode:
                             name: famine
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - depression
                                 - economic crisis
@@ -962,7 +962,7 @@ OntologyNode:
                             name: recession
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - adverse shocks
                                 - catastrophe
@@ -979,7 +979,7 @@ OntologyNode:
                             name: shocks
                             polarity: 1
                             semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - beliefs
                         - cultural norms
@@ -988,13 +988,13 @@ OntologyNode:
                     name: cultural_norms
                     polarity: 1
                     semantic type: entity
-                - OntologyNode:
+                - node:
                     examples:
                         - curfew
                     name: curfew
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - discrimination
                         - exclusion
@@ -1003,10 +1003,10 @@ OntologyNode:
                     name: discrimination
                     polarity: -1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     name: economy
                     children:
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - assets
                                 - holdings
@@ -1018,13 +1018,13 @@ OntologyNode:
                             name: assets
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - budget
                             name: budget
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - GDP
                                 - GNP
@@ -1057,7 +1057,7 @@ OntologyNode:
                             name: commerce
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - business
                                 - commercial enterprise
@@ -1066,7 +1066,7 @@ OntologyNode:
                             name: commercial_enterprise
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - commercial farm
                                 - commercial farming
@@ -1088,13 +1088,13 @@ OntologyNode:
                             name: commercial_farmers
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - competition
                             name: competition
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - cash
                                 - currency
@@ -1104,7 +1104,7 @@ OntologyNode:
                             name: currency
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - debt
                                 - deficit
@@ -1112,7 +1112,7 @@ OntologyNode:
                             name: debt
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - comparative advantages
                                 - economic benefits
@@ -1146,7 +1146,7 @@ OntologyNode:
                             name: economy
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - card
                                 - consumer prices
@@ -1167,7 +1167,7 @@ OntologyNode:
                             name: exchange_rate
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - charge
                                 - expense
@@ -1177,7 +1177,7 @@ OntologyNode:
                             name: expense
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - assets
                                 - award
@@ -1222,7 +1222,7 @@ OntologyNode:
                             name: finance
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - compensation
                                 - earnings
@@ -1236,7 +1236,7 @@ OntologyNode:
                             name: income
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - casual labour
                                 - decent work
@@ -1255,7 +1255,7 @@ OntologyNode:
                             name: labor
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - employment
                                 - job
@@ -1263,7 +1263,7 @@ OntologyNode:
                             name: livelihood
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - boxes
                                 - brands
@@ -1296,7 +1296,7 @@ OntologyNode:
                             name: marketing
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - bazaar
                                 - grocer
@@ -1317,7 +1317,7 @@ OntologyNode:
                             name: marketplace
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - disbursement
                                 - drawdown
@@ -1328,13 +1328,13 @@ OntologyNode:
                             name: payment
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - purchasing power
                             name: purchasing_power
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - entrepreneurs
                                 - entrepreneurship
@@ -1342,7 +1342,7 @@ OntologyNode:
                             name: small_businesses
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - farmers
                                 - fields
@@ -1370,7 +1370,7 @@ OntologyNode:
                             name: small_farmers
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - duties
                                 - revenue
@@ -1382,13 +1382,13 @@ OntologyNode:
                             name: taxes
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - unemployment
                             name: unemployment
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - labor
                                 - professionals
@@ -1398,7 +1398,7 @@ OntologyNode:
                             name: workforce
                             polarity: 1
                             semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - courses
                         - curriculum
@@ -1413,10 +1413,10 @@ OntologyNode:
                     name: education
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     name: entity
                     children:
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - african countries
                                 - african governments
@@ -1427,7 +1427,7 @@ OntologyNode:
                             name: african_governments
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - Harakat al-Shabaab al-Mujahideen
                                 - Mujahideen Youth Movement
@@ -1438,7 +1438,7 @@ OntologyNode:
                             name: al-shabaab
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - animal
                                 - animal resources
@@ -1484,20 +1484,20 @@ OntologyNode:
                             name: animal
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - artifact
                             name: artifact
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - border
                                 - land border
                             name: border
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - drone
                                 - drones
@@ -1509,7 +1509,7 @@ OntologyNode:
                             name: drone
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - chirps
                                 - climate information
@@ -1528,14 +1528,14 @@ OntologyNode:
                             name: field_reports
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - gang
                                 - gangs
                             name: gangs
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - GPE
                                 - city
@@ -1543,7 +1543,7 @@ OntologyNode:
                             name: geo-political_entity
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - administration
                                 - administrations
@@ -1571,13 +1571,13 @@ OntologyNode:
                             name: government_entity
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - hamas
                             name: hamas
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - agencies
                                 - aid
@@ -1615,14 +1615,14 @@ OntologyNode:
                             name: humanitarian_actors
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - indigenous communities
                                 - indigenous people
                             name: indigenous_communities
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - global community
                                 - international agencies
@@ -1634,17 +1634,17 @@ OntologyNode:
                             name: international_organizations
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - isil
                                 - isis
                             name: isil
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             name: locations
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - big cities
                                         - capitals
@@ -1660,7 +1660,7 @@ OntologyNode:
                                     name: city
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - city
                                         - country
@@ -1669,13 +1669,13 @@ OntologyNode:
                                     name: location
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - neighboring country
                                     name: neighboring_country
                                     polarity: 1
                                     semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - lord's resistance army
                                 - lord's resistance movement
@@ -1683,7 +1683,7 @@ OntologyNode:
                             name: lord's_resistance_army
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - military exercise
                                 - military game
@@ -1691,7 +1691,7 @@ OntologyNode:
                             name: military_exercise
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - military
                                 - military force
@@ -1699,7 +1699,7 @@ OntologyNode:
                             name: military_power
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - bilateral donors
                                 - development actors
@@ -1717,7 +1717,7 @@ OntologyNode:
                             name: multilateral_system
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - islam
                                 - mosque
@@ -1727,7 +1727,7 @@ OntologyNode:
                             name: muslim_communities
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - external actors
                                 - external intervention
@@ -1736,7 +1736,7 @@ OntologyNode:
                             name: nonstate_actors
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - opposition
                                 - opposition groups
@@ -1751,7 +1751,7 @@ OntologyNode:
                             name: opposition_party
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - NGO
                                 - community based organization
@@ -1761,10 +1761,10 @@ OntologyNode:
                             name: organization
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             name: people
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - academic
                                         - analyst
@@ -1785,7 +1785,7 @@ OntologyNode:
                                     name: academic
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - activist
                                         - crowd
@@ -1794,7 +1794,7 @@ OntologyNode:
                                     name: activist
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - adult
                                         - elder
@@ -1805,7 +1805,7 @@ OntologyNode:
                                     name: adults
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - adviser
                                         - advisor
@@ -1826,7 +1826,7 @@ OntologyNode:
                                     name: adviser
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - adolescent
                                         - child
@@ -1840,13 +1840,13 @@ OntologyNode:
                                     name: child_or_youth
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - citizen
                                     name: citizen
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - cartel
                                         - criminal
@@ -1859,7 +1859,7 @@ OntologyNode:
                                     name: criminal
                                     polarity: -1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - captive
                                         - detainee
@@ -1870,7 +1870,7 @@ OntologyNode:
                                     name: detainee
                                     polarity: -1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - aristocracy
                                         - aristocrat
@@ -1882,7 +1882,7 @@ OntologyNode:
                                     name: elites
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - VEO
                                         - crusader
@@ -1897,7 +1897,7 @@ OntologyNode:
                                     name: extremist
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - cowherd
                                         - farm worker
@@ -1914,7 +1914,7 @@ OntologyNode:
                                     name: farm_worker
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - ambassador
                                         - attorney general
@@ -1935,7 +1935,7 @@ OntologyNode:
                                     name: government_worker
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - CHW
                                         - community health worker
@@ -1948,7 +1948,7 @@ OntologyNode:
                                     name: health_worker
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     patterns:
                                         - household
                                     examples:
@@ -1969,7 +1969,7 @@ OntologyNode:
                                     name: household
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - baby
                                         - infant
@@ -1977,7 +1977,7 @@ OntologyNode:
                                     name: infant
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - landholder
                                         - landlord
@@ -1985,7 +1985,7 @@ OntologyNode:
                                     name: landowner
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - law enforcement
                                         - local officials
@@ -1997,7 +1997,7 @@ OntologyNode:
                                     name: law_enforcement_officials
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - maternal
                                         - mother
@@ -2005,7 +2005,7 @@ OntologyNode:
                                     name: maternal
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - husband
                                         - man
@@ -2013,10 +2013,10 @@ OntologyNode:
                                     name: men
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     name: migration
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - IDP
                                                 - displaced person
@@ -2024,14 +2024,14 @@ OntologyNode:
                                             name: displaced_person
                                             polarity: 1
                                             semantic type: entity
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - economic migrant
                                                 - migrant
                                             name: migrant
                                             polarity: -1
                                             semantic type: entity
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - asylum seeker
                                                 - refugee
@@ -2039,7 +2039,7 @@ OntologyNode:
                                             name: refugee
                                             polarity: 1
                                             semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - admiral
                                         - armed forces
@@ -2059,13 +2059,13 @@ OntologyNode:
                                     name: military_personnel
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - militia
                                     name: militia
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - anchor
                                         - blogger
@@ -2078,14 +2078,14 @@ OntologyNode:
                                     name: newsmedia
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - observer
                                         - watchdog
                                     name: observer
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - community
                                         - group
@@ -2095,7 +2095,7 @@ OntologyNode:
                                     name: person_or_group
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - insurgents
                                         - militant group
@@ -2103,20 +2103,20 @@ OntologyNode:
                                     name: rebels
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - task force
                                         - taskforce
                                     name: taskforce
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - voter
                                     name: voter
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - bride
                                         - female farmers
@@ -2131,7 +2131,7 @@ OntologyNode:
                                     name: women
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - young adults
                                         - young men
@@ -2139,7 +2139,7 @@ OntologyNode:
                                     name: young_adults
                                     polarity: 1
                                     semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - church
                                 - congregation
@@ -2148,7 +2148,7 @@ OntologyNode:
                             name: religious_entity
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             definition: 'note: in Kenya, the ruling party is the Jubilee party'
                             examples:
                                 - incumbent
@@ -2159,7 +2159,7 @@ OntologyNode:
                             name: ruling_party
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - communes
                                 - farmlands
@@ -2182,7 +2182,7 @@ OntologyNode:
                             name: rural_households
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - cities
                                 - city
@@ -2201,7 +2201,7 @@ OntologyNode:
                             name: urban_households
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - SUV
                                 - aeroplane
@@ -2223,7 +2223,7 @@ OntologyNode:
                             name: vehicle
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - ammunition
                                 - explosives
@@ -2235,16 +2235,16 @@ OntologyNode:
                             name: weapons
                             polarity: 1
                             semantic type: entity
-                - OntologyNode:
+                - node:
                     name: environment
                     children:
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - climate
                             name: climate
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - changing climate
                                 - climate
@@ -2273,7 +2273,7 @@ OntologyNode:
                             name: climate_change
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - biodiversity
                                 - ecology
@@ -2284,7 +2284,7 @@ OntologyNode:
                             name: ecology
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - aerosol
                                 - aerosols
@@ -2306,13 +2306,13 @@ OntologyNode:
                             name: emissions
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - environmental impacts
                             name: environmental_impacts
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - afforestation
                                 - agroforestry
@@ -2337,7 +2337,7 @@ OntologyNode:
                             name: forestry
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - climate changes
                                 - degrees
@@ -2356,10 +2356,10 @@ OntologyNode:
                             name: higher_temperatures
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             name: meteorology
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - precipitation
                                         - rain
@@ -2368,13 +2368,13 @@ OntologyNode:
                                     name: precipitation
                                     polarity: 1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - temperature
                                     name: temperature
                                     polarity: 1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     definition: The state of the atmosphere, describing the degree to which it is hot or cold, wet or dry, calm or stormy, clear or cloudy.
                                     examples:
                                         - climate variability
@@ -2391,10 +2391,10 @@ OntologyNode:
                                     name: weather
                                     polarity: 1
                                     semantic type: event
-                        - OntologyNode:
+                        - node:
                             name: natural_resources
                             children:
-                                - OntologyNode:
+                                - node:
                                     definition: Fuels formed from natural processes, containing organic molecules, that release energy in combustion.
                                     examples:
                                         - carbon
@@ -2405,13 +2405,13 @@ OntologyNode:
                                     name: fossil_fuels
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - groundwater
                                     name: groundwater
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - acreage
                                         - arable land
@@ -2423,7 +2423,7 @@ OntologyNode:
                                     name: land
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     definition: Land used for grazing by domesticated livestock.
                                     examples:
                                         - grazing
@@ -2434,7 +2434,7 @@ OntologyNode:
                                     name: pasture
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - leaching into the soil
                                         - soil
@@ -2442,7 +2442,7 @@ OntologyNode:
                                     name: soil
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - aqueduct
                                         - lake
@@ -2454,7 +2454,7 @@ OntologyNode:
                                     name: water_bodies
                                     polarity: 1
                                     semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - air pollution
                                 - contamination
@@ -2464,26 +2464,26 @@ OntologyNode:
                             name: pollution
                             polarity: -1
                             semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - ethnic diversity
                         - ethnic minorities
                     name: ethnic_diversity
                     polarity: 1
                     semantic type: entity
-                - OntologyNode:
+                - node:
                     examples:
                         - freedom
                     name: freedom
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     name: goods
                     children:
-                        - OntologyNode:
+                        - node:
                             name: agricultural
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - compound feed
                                         - compound poultry feed
@@ -2494,7 +2494,7 @@ OntologyNode:
                                     name: compound_feed
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - farm equipment
                                         - machinery
@@ -2506,7 +2506,7 @@ OntologyNode:
                                     name: farm_equipment
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - CSB
                                         - corn meal
@@ -2518,7 +2518,7 @@ OntologyNode:
                                     name: feed
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     patterns:
                                         - \b(manure|fertilizers?|nitrogen)\b
                                     examples:
@@ -2533,7 +2533,7 @@ OntologyNode:
                                     name: fertilizer
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - drip
                                         - electric pump
@@ -2547,7 +2547,7 @@ OntologyNode:
                                     name: irrigation_equipment
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - animal production
                                         - beef
@@ -2607,7 +2607,7 @@ OntologyNode:
                                     name: meat
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     patterns:
                                         - \b(DDT|dicamba|round-up)\b
                                     examples:
@@ -2619,7 +2619,7 @@ OntologyNode:
                                     name: pesticide
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - GMO
                                         - heirloom seed
@@ -2629,7 +2629,7 @@ OntologyNode:
                                     name: seed
                                     polarity: 1
                                     semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - concrete cement
                                 - construction materials
@@ -2637,7 +2637,7 @@ OntologyNode:
                             name: construction_materials
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - chalkboard
                                 - education supplies
@@ -2648,7 +2648,7 @@ OntologyNode:
                             name: education_supplies
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - bread
                                 - breakfast
@@ -2685,7 +2685,7 @@ OntologyNode:
                             name: food
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - fuel
                                 - gas
@@ -2693,7 +2693,7 @@ OntologyNode:
                             name: fuel
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - bandages
                                 - bed
@@ -2704,7 +2704,7 @@ OntologyNode:
                             name: medical_supplies
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - antibiotics
                                 - antimicrobial
@@ -2725,7 +2725,7 @@ OntologyNode:
                             name: medicine
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - aluminium
                                 - aluminum
@@ -2741,7 +2741,7 @@ OntologyNode:
                             name: minerals
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - clean water
                                 - drinking water
@@ -2752,7 +2752,7 @@ OntologyNode:
                             name: potable_water
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - alfalfa
                                 - bean
@@ -2780,7 +2780,7 @@ OntologyNode:
                             name: protein_foods
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - H20
                                 - aqua
@@ -2788,16 +2788,16 @@ OntologyNode:
                             name: water
                             polarity: 1
                             semantic type: entity
-                - OntologyNode:
+                - node:
                     name: government
                     children:
-                        - OntologyNode:
+                        - node:
                             name: corruption
                             children:
-                                - OntologyNode:
+                                - node:
                                     name: corrupt_policy
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - cronyism
                                                 - favoritism
@@ -2809,7 +2809,7 @@ OntologyNode:
                                             name: cronyism
                                             polarity: 1
                                             semantic type: event
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - campaign financing irregularities
                                                 - conflict of interest
@@ -2819,7 +2819,7 @@ OntologyNode:
                                             name: illicit_political_financing
                                             polarity: 1
                                             semantic type: entity
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - bribery
                                                 - corrupt parliamentary oversight
@@ -2832,7 +2832,7 @@ OntologyNode:
                                             name: parliamentary_corruption
                                             polarity: 1
                                             semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - ballot burning
                                         - ballot stuffing
@@ -2852,7 +2852,7 @@ OntologyNode:
                                     name: election_manipulation
                                     polarity: 1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - arbitrary arrests
                                         - bribery
@@ -2863,14 +2863,14 @@ OntologyNode:
                                     name: government_corruption
                                     polarity: 1
                                     semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - decentralization
                                 - decentralize
                             name: decentralization
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - foreign affairs
                                 - international affairs
@@ -2879,7 +2879,7 @@ OntologyNode:
                             name: diplomatic_relations
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - ballot
                                 - caucus
@@ -2889,7 +2889,7 @@ OntologyNode:
                             name: election
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - election cycle
                                 - election process
@@ -2899,7 +2899,7 @@ OntologyNode:
                             name: election_process
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - diplomats
                                 - foreign affairs
@@ -2911,7 +2911,7 @@ OntologyNode:
                             name: foreign_policy
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - census
                                 - policy
@@ -2922,7 +2922,7 @@ OntologyNode:
                             name: government_program
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - court system
                                 - courthouse
@@ -2933,7 +2933,7 @@ OntologyNode:
                             name: judicial_system
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - act
                                 - appropriate policies
@@ -2958,14 +2958,14 @@ OntologyNode:
                             name: legislation
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - political influence
                                 - political power
                             name: political_power
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - authoritarianism
                                 - autocracy
@@ -2981,7 +2981,7 @@ OntologyNode:
                             name: political_system
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - polling staff
                                 - polling station
@@ -2989,14 +2989,14 @@ OntologyNode:
                             name: polling_stations
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             definition: A restriction on trade, or measures by a country on a state or individual intended to elicit a change in their behavior.
                             examples:
                                 - sanction
                             name: sanction
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - failed states
                                 - state collapse
@@ -3004,7 +3004,7 @@ OntologyNode:
                             name: state_collapse
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - central authority
                                 - congressional power
@@ -3019,16 +3019,16 @@ OntologyNode:
                             name: state_power
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - government change
                             name: transition_of_power
                             polarity: 1
                             semantic type: event
-                - OntologyNode:
+                - node:
                     name: health
                     children:
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - antibodies
                                 - antibody
@@ -3036,7 +3036,7 @@ OntologyNode:
                             name: antibody
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - DNA
                                 - biometrics
@@ -3044,7 +3044,7 @@ OntologyNode:
                             name: biometrics
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             patterns:
                                 - \b(case\s+volume)\b
                                 - \b(new\s+cases)\b
@@ -3059,17 +3059,17 @@ OntologyNode:
                             name: case_volume
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             name: disease
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - aids
                                         - hiv
                                     name: AIDS
                                     polarity: -1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     patterns:
                                         - (COVID|covid|SARS-CoV)
                                         - corona(\s+)?virus
@@ -3081,14 +3081,14 @@ OntologyNode:
                                     name: COVID
                                     polarity: -1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - flu
                                         - influenza
                                     name: flu
                                     polarity: -1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - anaemia
                                         - cancer
@@ -3118,13 +3118,13 @@ OntologyNode:
                                     name: illness
                                     polarity: -1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - malaria
                                     name: malaria
                                     polarity: -1
                                     semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - alleles
                                 - carriers
@@ -3151,7 +3151,7 @@ OntologyNode:
                             name: gene
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - health
                                 - healthcare
@@ -3159,7 +3159,7 @@ OntologyNode:
                             name: healthcare
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - PPE
                                 - face covering
@@ -3171,14 +3171,14 @@ OntologyNode:
                             name: hygiene_materials
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - injury
                                 - wound
                             name: injury
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - assessments
                                 - characterization
@@ -3208,7 +3208,7 @@ OntologyNode:
                             name: laboratory_testing
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - life
                                 - lives
@@ -3216,7 +3216,7 @@ OntologyNode:
                             name: life
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - acute malnutrition
                                 - gam
@@ -3237,7 +3237,7 @@ OntologyNode:
                             name: malnutrition
                             polarity: -1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - DALY
                                 - disability
@@ -3247,7 +3247,7 @@ OntologyNode:
                             name: morbidity
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - adequate amounts
                                 - bioavailability
@@ -3296,7 +3296,7 @@ OntologyNode:
                             name: nutrients
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - bioavailability
                                 - diet
@@ -3309,7 +3309,7 @@ OntologyNode:
                             name: nutrition
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - bacteria
                                 - bacterium
@@ -3340,7 +3340,7 @@ OntologyNode:
                             name: pathogen
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - child mortality
                                 - child stunting
@@ -3350,7 +3350,7 @@ OntologyNode:
                             name: poor_childrens_health
                             polarity: -1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - crude protein
                                 - protein
@@ -3361,20 +3361,20 @@ OntologyNode:
                             name: protein_nutrient
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - population health
                                 - public health
                             name: public_health
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - public safety
                             name: public_safety
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - alcohol abuse
                                 - cocaine
@@ -3386,16 +3386,16 @@ OntologyNode:
                             name: substance_abuse
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             name: treatment
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - intensive care
                                     name: intensive_care
                                     polarity: 1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - preventative treatment
                                         - prophylactic
@@ -3404,7 +3404,7 @@ OntologyNode:
                                     name: preventative_treatment
                                     polarity: 1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - anti-depressant
                                         - counseling
@@ -3415,7 +3415,7 @@ OntologyNode:
                                     name: psychological_services
                                     polarity: 1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - additional feed
                                         - cumulative feed
@@ -3433,7 +3433,7 @@ OntologyNode:
                                     name: supplemental_feed
                                     polarity: 1
                                     semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - cell
                                 - covax
@@ -3455,7 +3455,7 @@ OntologyNode:
                             name: vaccination
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             definition: An agent that carries or transmits an infectious pathogen into another living organism.
                             examples:
                                 - excrement
@@ -3466,7 +3466,7 @@ OntologyNode:
                             name: vector
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - body size
                                 - body weight
@@ -3484,20 +3484,20 @@ OntologyNode:
                             name: weight_gain
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - living condition
                                 - welfare
                             name: welfare
                             polarity: 1
                             semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - homeless
                     name: homelessness
                     polarity: -1
                     semantic type: entity
-                - OntologyNode:
+                - node:
                     examples:
                         - freedom
                         - freedoms
@@ -3507,10 +3507,10 @@ OntologyNode:
                     name: human_rights
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     name: humanitarian_assistance
                     children:
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - CSB
                                 - food aid
@@ -3522,7 +3522,7 @@ OntologyNode:
                             name: food_aid
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - development assistance
                                 - emergency aid
@@ -3536,7 +3536,7 @@ OntologyNode:
                             name: humanitarian_assistance
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - NFI
                                 - buckets
@@ -3549,7 +3549,7 @@ OntologyNode:
                             name: non_food_items
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             patterns:
                                 - \bcash\b
                                 - \bvouchers?\b
@@ -3561,7 +3561,7 @@ OntologyNode:
                             name: voucher_or_cash
                             polarity: 1
                             semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - discrepancy
                         - disparity
@@ -3571,10 +3571,10 @@ OntologyNode:
                     name: inequality
                     polarity: -1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     name: information
                     children:
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - computers
                                 - digital technologies
@@ -3582,7 +3582,7 @@ OntologyNode:
                             name: information_technology
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - intelligence
                                 - intelligence analysis
@@ -3590,7 +3590,7 @@ OntologyNode:
                             name: intelligence_information
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - internet
                                 - mobile internet
@@ -3599,7 +3599,7 @@ OntologyNode:
                             name: internet
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - disinformation
                                 - fake news
@@ -3611,7 +3611,7 @@ OntologyNode:
                             name: misinformation
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - allegation
                                 - myth
@@ -3622,7 +3622,7 @@ OntologyNode:
                             name: rumor
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - facebook
                                 - instagram
@@ -3631,13 +3631,13 @@ OntologyNode:
                             name: social_media
                             polarity: 1
                             semantic type: entity
-                - OntologyNode:
+                - node:
                     name: infrastructure
                     children:
-                        - OntologyNode:
+                        - node:
                             name: agriculture
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - barn
                                         - farm infrastructure
@@ -3648,7 +3648,7 @@ OntologyNode:
                                     name: farm_infrastructure
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - agricultural land
                                         - arable land
@@ -3656,7 +3656,7 @@ OntologyNode:
                                     name: farmland
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - broiler producers
                                         - poultry producers
@@ -3670,7 +3670,7 @@ OntologyNode:
                                     name: slaughterhouse
                                     polarity: 1
                                     semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - advertisement
                                 - article
@@ -3700,7 +3700,7 @@ OntologyNode:
                             name: communication
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - campus
                                 - child friendly learning spaces
@@ -3717,7 +3717,7 @@ OntologyNode:
                             name: education_facilities
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - electrical wiring
                                 - electricity
@@ -3729,7 +3729,7 @@ OntologyNode:
                             name: electrical_infrastructure
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - electricity
                                 - energy
@@ -3738,7 +3738,7 @@ OntologyNode:
                             name: energy
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - dam
                                 - energy
@@ -3751,7 +3751,7 @@ OntologyNode:
                             name: energy_infrastructure
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - dike
                                 - flood wall
@@ -3760,7 +3760,7 @@ OntologyNode:
                             name: flood_mitigation_infrastructure
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - buildings
                                 - floors
@@ -3773,7 +3773,7 @@ OntologyNode:
                             name: housing
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             patterns:
                                 - irrigation
                             examples:
@@ -3782,7 +3782,7 @@ OntologyNode:
                             name: irrigation_infrastructure
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             patterns:
                                 - \bclinics\b
                                 - \bhospitals?\b
@@ -3804,14 +3804,14 @@ OntologyNode:
                             name: medical_facilities
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - mine
                                 - mineshaft
                             name: mining_infrastructure
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             patterns:
                                 - \bcamps?\b
                                 - \brefugee\s+camps?\b
@@ -3823,7 +3823,7 @@ OntologyNode:
                             name: refugee_camps
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             patterns:
                                 - \blatrines?\b
                                 - \btoilets?\b
@@ -3835,23 +3835,23 @@ OntologyNode:
                             name: sanitation_infrastructure
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             name: transportation
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - bridge
                                     name: bridge
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - public transport
                                         - public transportation
                                     name: public_transportation
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - rail
                                         - railroad
@@ -3859,7 +3859,7 @@ OntologyNode:
                                     name: railroad_infrastructure
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - highway
                                         - road
@@ -3868,7 +3868,7 @@ OntologyNode:
                                     name: road_infrastructure
                                     polarity: 1
                                     semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - ballot boxes
                                 - polling booths
@@ -3878,7 +3878,7 @@ OntologyNode:
                             name: voting_infrastructure
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             patterns:
                                 - \bborehole
                             examples:
@@ -3890,7 +3890,7 @@ OntologyNode:
                             name: water_facilities
                             polarity: 1
                             semantic type: entity
-                - OntologyNode:
+                - node:
                     examples:
                         - appropriate technologies
                         - different approaches
@@ -3912,7 +3912,7 @@ OntologyNode:
                     name: innovation
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - approaches
                         - appropriate actions
@@ -3946,13 +3946,13 @@ OntologyNode:
                     name: intervention
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - literacy
                     name: literacy
                     polarity: 1
                     semantic type: entity
-                - OntologyNode:
+                - node:
                     examples:
                         - antimicrobials
                         - biotechnologies
@@ -3968,7 +3968,7 @@ OntologyNode:
                     name: microbiology
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - opinion
                         - perception
@@ -3976,7 +3976,7 @@ OntologyNode:
                     name: perception
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - action
                         - action plan
@@ -4003,7 +4003,7 @@ OntologyNode:
                     name: plan
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - decision making
                         - policy
@@ -4014,23 +4014,23 @@ OntologyNode:
                     name: policy_making
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     name: population_demographics
                     children:
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - age
                             name: age
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - clan
                                 - family
                             name: clan
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - ethnic identities
                                 - ethnic identity
@@ -4040,7 +4040,7 @@ OntologyNode:
                             name: ethnic_identity
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - empowerment
                                 - equal opportunities
@@ -4060,10 +4060,10 @@ OntologyNode:
                             name: gender
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             name: population_density
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - de-population
                                         - depopulation
@@ -4071,32 +4071,32 @@ OntologyNode:
                                     name: de-population
                                     polarity: -1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - overcrowding
                                     name: overcrowding
                                     polarity: 1
                                     semantic type: entity
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - population growth
                                     name: population_growth
                                     polarity: 1
                                     semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - ethnicity
                                 - race
                             name: race_or_ethnicity
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - religion
                             name: religion
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - ethnicity
                                 - tribal
@@ -4104,7 +4104,7 @@ OntologyNode:
                             name: tribe
                             polarity: 1
                             semantic type: entity
-                - OntologyNode:
+                - node:
                     examples:
                         - poor communities
                         - poor consumers
@@ -4117,7 +4117,7 @@ OntologyNode:
                     name: poverty
                     polarity: -1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - bans
                         - ceilings
@@ -4132,7 +4132,7 @@ OntologyNode:
                     name: regulations
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - celebration
                         - ceremony
@@ -4145,7 +4145,7 @@ OntologyNode:
                     name: ritual
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - basic services
                         - civil registration
@@ -4161,7 +4161,7 @@ OntologyNode:
                     name: safety_net
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - carcasses
                         - culling
@@ -4169,10 +4169,10 @@ OntologyNode:
                     name: scavenging_system
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     name: security
                     children:
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - community
                                 - mine clearance
@@ -4180,7 +4180,7 @@ OntologyNode:
                             name: community_security
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - depreciation
                                 - economic security
@@ -4190,13 +4190,13 @@ OntologyNode:
                             name: economic_security
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - environmental security
                             name: environmental_security
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - diplomacy
                                 - military
@@ -4204,7 +4204,7 @@ OntologyNode:
                             name: national_security
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - informant
                                 - monitor
@@ -4214,7 +4214,7 @@ OntologyNode:
                             name: surveillance_system
                             polarity: 1
                             semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - cultural factors
                         - individual characteristics
@@ -4240,10 +4240,10 @@ OntologyNode:
                     name: social_structure_or_relationship
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     name: storage
                     children:
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - agricultural storage
                                 - granary
@@ -4252,7 +4252,7 @@ OntologyNode:
                             name: agricultural_storage
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - storage
                                 - storage facilities
@@ -4260,23 +4260,23 @@ OntologyNode:
                             name: general_storage_facilities
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - household food storage
                                 - storage
                             name: household_food_storage
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - stockpile
                             name: stockpile_goods
                             polarity: 1
                             semantic type: entity
-                - OntologyNode:
+                - node:
                     name: time
                     children:
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - delay
                                 - halt
@@ -4286,7 +4286,7 @@ OntologyNode:
                             name: delay
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - arid
                                 - drought
@@ -4297,7 +4297,7 @@ OntologyNode:
                             name: dry_season
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - ongoing
                                 - prolonged
@@ -4305,7 +4305,7 @@ OntologyNode:
                             name: prolonged
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - crop calendar
                                 - crop season
@@ -4316,7 +4316,7 @@ OntologyNode:
                             name: season
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - long rains
                                 - monsoon
@@ -4327,7 +4327,7 @@ OntologyNode:
                             name: wet_season
                             polarity: 1
                             semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - bias
                         - demographics
@@ -4338,30 +4338,30 @@ OntologyNode:
                     name: trend
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - attendance
                         - turnout
                     name: turnout
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - urbanization
                     name: urbanization
                     polarity: 1
                     semantic type: event
-        - OntologyNode:
+        - node:
             name: process
             children:
-                - OntologyNode:
+                - node:
                     definition: The ability or right to approach, enter, exit, make use of, or communicate with something.
                     examples:
                         - access
                     name: access
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - adapt
                         - adaptability
@@ -4370,7 +4370,7 @@ OntologyNode:
                     name: adapt
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - aid
                         - assist
@@ -4380,7 +4380,7 @@ OntologyNode:
                     name: aid_or_assistance
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - analyze
                         - assess
@@ -4389,7 +4389,7 @@ OntologyNode:
                     name: assessment
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - attempt
                         - campaign
@@ -4400,7 +4400,7 @@ OntologyNode:
                     name: attempt
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - breed
                         - breeder
@@ -4441,13 +4441,13 @@ OntologyNode:
                     name: breeding
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - censorship
                     name: censorship
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - clean
                         - clean up
@@ -4458,7 +4458,7 @@ OntologyNode:
                     name: clean
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - alliance
                         - allied
@@ -4472,7 +4472,7 @@ OntologyNode:
                     name: collaboration
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - collect
                         - collecting
@@ -4483,7 +4483,7 @@ OntologyNode:
                     name: collecting
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - combine
                         - couple
@@ -4495,20 +4495,20 @@ OntologyNode:
                     name: combining
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     name: communication
                     children:
-                        - OntologyNode:
+                        - node:
                             name: ask
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - canvass
                                         - poll
                                     name: poll
                                     polarity: 1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - ask
                                         - interrogate
@@ -4517,7 +4517,7 @@ OntologyNode:
                                     name: question
                                     polarity: 1
                                     semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - advocate
                                 - campaign
@@ -4529,7 +4529,7 @@ OntologyNode:
                             name: campaign
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - commit
                                 - commitment
@@ -4538,7 +4538,7 @@ OntologyNode:
                             name: commitment
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - argue
                                 - assert
@@ -4550,7 +4550,7 @@ OntologyNode:
                             name: debate
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - deceive
                                 - deception
@@ -4560,7 +4560,7 @@ OntologyNode:
                             name: deception
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - describe
                                 - description
@@ -4572,7 +4572,7 @@ OntologyNode:
                             name: description
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - advocate
                                 - approve
@@ -4583,7 +4583,7 @@ OntologyNode:
                             name: endorsement
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - distinguish
                                 - emphasise
@@ -4592,7 +4592,7 @@ OntologyNode:
                             name: highlighting
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - disclose
                                 - inform
@@ -4603,7 +4603,7 @@ OntologyNode:
                             name: informing
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - arbitrate
                                 - broker
@@ -4613,7 +4613,7 @@ OntologyNode:
                             name: mediation
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - assembly
                                 - conference
@@ -4631,7 +4631,7 @@ OntologyNode:
                             name: meeting
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - bargain
                                 - negotiate
@@ -4639,7 +4639,7 @@ OntologyNode:
                             name: negotiation
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - challenge
                                 - condemn
@@ -4661,7 +4661,7 @@ OntologyNode:
                             name: opposition
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - recommend
                                 - recommendation
@@ -4670,7 +4670,7 @@ OntologyNode:
                             name: suggestion
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - caution
                                 - warn
@@ -4678,10 +4678,10 @@ OntologyNode:
                             name: warning
                             polarity: 1
                             semantic type: event
-                - OntologyNode:
+                - node:
                     name: conflict
                     children:
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - abducted
                                 - abduction
@@ -4694,7 +4694,7 @@ OntologyNode:
                             name: abduction
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - abuse
                                 - harass
@@ -4704,14 +4704,14 @@ OntologyNode:
                             name: abuse
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - assassinate
                                 - assassination
                             name: assassination
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - airstrike
                                 - ambush
@@ -4740,7 +4740,7 @@ OntologyNode:
                             name: attack
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - clan conflict
                                 - clan differences
@@ -4748,7 +4748,7 @@ OntologyNode:
                             name: clan_conflict
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - crackdown
                                 - crush
@@ -4758,7 +4758,7 @@ OntologyNode:
                             name: crackdown
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - collapse
                                 - coup
@@ -4773,14 +4773,14 @@ OntologyNode:
                             name: defeat
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - ceasefire
                                 - disarmament
                             name: disarmament
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - discriminate
                                 - exclude
@@ -4791,7 +4791,7 @@ OntologyNode:
                             name: discriminate
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - draft
                                 - enlist
@@ -4801,7 +4801,7 @@ OntologyNode:
                             name: enlist
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             definition: To make use of (sometimes unfairly) to one's own advantage.
                             examples:
                                 - cheat
@@ -4813,7 +4813,7 @@ OntologyNode:
                             name: exploit
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - harass
                                 - harassment
@@ -4822,7 +4822,7 @@ OntologyNode:
                             name: harass_or_persecute
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - insurgency
                                 - revolt
@@ -4830,7 +4830,7 @@ OntologyNode:
                             name: insurgency
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - conflict prevention
                                 - conflict resolution
@@ -4853,20 +4853,20 @@ OntologyNode:
                             name: peacebuilding
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - peacekeepers
                                 - peacekeeping
                             name: peacekeeping
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - police brutality
                             name: police_brutality
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - assemble
                                 - boycott
@@ -4886,7 +4886,7 @@ OntologyNode:
                             name: protest_or_demonstration
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - accord
                                 - accords
@@ -4906,7 +4906,7 @@ OntologyNode:
                             name: resolution
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - retaliation
                                 - retribution
@@ -4914,7 +4914,7 @@ OntologyNode:
                             name: retaliation
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - bomb threat
                                 - extremism
@@ -4930,7 +4930,7 @@ OntologyNode:
                             name: terrorism
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - intimidate
                                 - threat
@@ -4938,14 +4938,14 @@ OntologyNode:
                             name: threat
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - excessive force
                                 - torture
                             name: torture
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - ethnic conflict
                                 - ethnic conflicts
@@ -4961,7 +4961,7 @@ OntologyNode:
                             name: tribal_conflict
                             polarity: -1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - assault
                                 - attack
@@ -4978,7 +4978,7 @@ OntologyNode:
                             name: war
                             polarity: -1
                             semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - build
                         - building
@@ -4988,7 +4988,7 @@ OntologyNode:
                     name: construction
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - consume
                         - consumption
@@ -4998,7 +4998,7 @@ OntologyNode:
                     name: consumption
                     polarity: -1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - damage
                         - devastate
@@ -5006,7 +5006,7 @@ OntologyNode:
                     name: damage
                     polarity: -1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - conclude
                         - decide
@@ -5014,7 +5014,7 @@ OntologyNode:
                     name: decision
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - demand
                         - petition
@@ -5022,7 +5022,7 @@ OntologyNode:
                     name: demand
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - deploy
                         - deployment
@@ -5030,20 +5030,20 @@ OntologyNode:
                     name: deployment
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - depreciate
                         - devaluation
                     name: depreciation
                     polarity: -1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - destabilize
                     name: destabilization
                     polarity: -1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - destroy
                         - destruction
@@ -5051,7 +5051,7 @@ OntologyNode:
                     name: destruction
                     polarity: -1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - clinical signs
                         - detect
@@ -5062,7 +5062,7 @@ OntologyNode:
                     name: detection
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - broaden
                         - cultivate
@@ -5075,7 +5075,7 @@ OntologyNode:
                     name: development
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - conceal
                         - disguise
@@ -5087,7 +5087,7 @@ OntologyNode:
                     name: disguise
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - boost
                         - enhance
@@ -5101,21 +5101,21 @@ OntologyNode:
                     name: enhancement
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - evacuate
                         - evacuation
                     name: evacuation
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - dispossession
                         - eviction
                     name: eviction
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - discovery
                         - experimentation
@@ -5125,7 +5125,7 @@ OntologyNode:
                     name: exploration
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - compose
                         - derive
@@ -5136,10 +5136,10 @@ OntologyNode:
                     name: extraction
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     name: farming
                     children:
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - harvest
                                 - harvesting
@@ -5147,7 +5147,7 @@ OntologyNode:
                             name: harvesting
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - grazing
                                 - herders
@@ -5156,7 +5156,7 @@ OntologyNode:
                             name: herding
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             definition: The process of applying controlled amounts of water to plants.
                             examples:
                                 - irrigate
@@ -5165,7 +5165,7 @@ OntologyNode:
                             name: irrigation
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - cultivate
                                 - planting
@@ -5173,19 +5173,19 @@ OntologyNode:
                             name: planting
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - tilling
                             name: tilling
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - weeding
                             name: weeding
                             polarity: 1
                             semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - aquaculture
                         - fish
@@ -5194,7 +5194,7 @@ OntologyNode:
                     name: fishing
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - diffuse
                         - diffusion
@@ -5203,13 +5203,13 @@ OntologyNode:
                     name: flow
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - forage
                     name: foraging
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - band
                         - categorize
@@ -5220,7 +5220,7 @@ OntologyNode:
                     name: grouping
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - abundance
                         - chick survival
@@ -5238,14 +5238,14 @@ OntologyNode:
                     name: hatching
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - hunt
                         - poaching
                     name: hunting
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - arrest
                         - captivity
@@ -5260,7 +5260,7 @@ OntologyNode:
                     name: imprisonment_or_detention
                     polarity: -1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - artificial incubation
                         - brooder
@@ -5279,7 +5279,7 @@ OntologyNode:
                     name: incubation
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     patterns:
                         - \b[iI]nfest
                     examples:
@@ -5288,13 +5288,13 @@ OntologyNode:
                     name: infestation
                     polarity: -1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - inflation
                     name: inflation
                     polarity: -1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - inhabit
                         - live
@@ -5304,7 +5304,7 @@ OntologyNode:
                     name: inhabiting_or_occupancy
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - consumption
                         - eating
@@ -5312,7 +5312,7 @@ OntologyNode:
                     name: intake
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - audit
                         - inquiry
@@ -5321,7 +5321,7 @@ OntologyNode:
                     name: investigate
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - FDI
                         - foreign direct investment
@@ -5332,10 +5332,10 @@ OntologyNode:
                     name: investment
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     name: judicial
                     children:
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - charge
                                 - indict
@@ -5343,7 +5343,7 @@ OntologyNode:
                             name: charge_or_prosecution
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - convict
                                 - conviction
@@ -5357,10 +5357,10 @@ OntologyNode:
                             name: conviction_or_sentencing
                             polarity: 1
                             semantic type: event
-                - OntologyNode:
+                - node:
                     name: legislation
                     children:
-                        - OntologyNode:
+                        - node:
                             patterns:
                                 - \b(regulations?|laws?)\b
                             examples:
@@ -5374,14 +5374,14 @@ OntologyNode:
                             name: regulation
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - subsidize
                                 - subsidy
                             name: subsidization
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - duty
                                 - levy
@@ -5391,7 +5391,7 @@ OntologyNode:
                             name: taxation
                             polarity: 1
                             semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - NRM
                         - administrate
@@ -5402,7 +5402,7 @@ OntologyNode:
                     name: management
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - control
                         - exploit
@@ -5411,10 +5411,10 @@ OntologyNode:
                     name: manipulation
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     name: medical
                     children:
-                        - OntologyNode:
+                        - node:
                             patterns:
                                 - (contact tracing)
                             examples:
@@ -5422,13 +5422,13 @@ OntologyNode:
                             name: contact_tracing
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - lockdown
                             name: lockdown
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             patterns:
                                 - (quarantin|shelter[- ]in[- ]place)
                                 - \b(restrict\s+movement)
@@ -5438,7 +5438,7 @@ OntologyNode:
                             name: quarantine
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - cleaning
                                 - disinfect
@@ -5448,7 +5448,7 @@ OntologyNode:
                             name: sanitization
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             patterns:
                                 - (social distanc)
                             examples:
@@ -5457,7 +5457,7 @@ OntologyNode:
                             name: social_distancing
                             polarity: 1
                             semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - drilling
                         - fracking
@@ -5465,7 +5465,7 @@ OntologyNode:
                     name: mining
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     definition: make less severe, serious, or painful; lessen the gravity
                     examples:
                         - alleviate
@@ -5481,14 +5481,14 @@ OntologyNode:
                     name: mitigation
                     polarity: -1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - change
                         - modify
                     name: modification
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - drive
                         - drove
@@ -5503,14 +5503,14 @@ OntologyNode:
                     name: motivation
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - nominate
                         - nomination
                     name: nomination
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - detect
                         - observe
@@ -5521,7 +5521,7 @@ OntologyNode:
                     name: observation
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - outbreak
                         - outbreaks
@@ -5530,7 +5530,7 @@ OntologyNode:
                     name: outbreak
                     polarity: -1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - design
                         - plan
@@ -5538,10 +5538,10 @@ OntologyNode:
                     name: planning
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     name: population
                     children:
-                        - OntologyNode:
+                        - node:
                             patterns:
                                 - birth
                             examples:
@@ -5549,7 +5549,7 @@ OntologyNode:
                             name: birth
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - burial
                                 - casualties
@@ -5570,10 +5570,10 @@ OntologyNode:
                             name: death
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             name: migrate
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - deport
                                         - emigrate
@@ -5582,7 +5582,7 @@ OntologyNode:
                                     name: emigrate
                                     polarity: 1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - asylum
                                         - immigrate
@@ -5591,7 +5591,7 @@ OntologyNode:
                                     name: immigrate
                                     polarity: 1
                                     semantic type: event
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - flee
                                         - migrate
@@ -5600,7 +5600,7 @@ OntologyNode:
                                     name: migrate
                                     polarity: 1
                                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - anticipate
                         - forecast
@@ -5611,7 +5611,7 @@ OntologyNode:
                     name: prediction
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - organize
                         - plan
@@ -5619,7 +5619,7 @@ OntologyNode:
                     name: preparation
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     definition: keep something from happening or arising
                     examples:
                         - limit
@@ -5629,7 +5629,7 @@ OntologyNode:
                     name: prevention
                     polarity: -1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - cleaning
                         - grading
@@ -5642,7 +5642,7 @@ OntologyNode:
                     name: processing
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     patterns:
                         - \b([pP]roduction|[yY]ields?)\b
                     examples:
@@ -5652,7 +5652,7 @@ OntologyNode:
                     name: production
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - ban
                         - criminalize
@@ -5661,7 +5661,7 @@ OntologyNode:
                     name: prohibition
                     polarity: -1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - administer
                         - deliver
@@ -5672,7 +5672,7 @@ OntologyNode:
                     name: provision
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - broadcast
                         - print
@@ -5684,13 +5684,13 @@ OntologyNode:
                     name: publication
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - radicalization
                     name: radicalization
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - react
                         - reaction
@@ -5699,14 +5699,14 @@ OntologyNode:
                     name: reaction_or_response
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - forgiveness
                         - relief
                     name: relief
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     definition: provide a remedy for; redress or make right; restore by reversing or stopping environmental damage
                     examples:
                         - reconcile
@@ -5717,7 +5717,7 @@ OntologyNode:
                     name: remediation
                     polarity: -1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - reconstruct
                         - repair
@@ -5725,7 +5725,7 @@ OntologyNode:
                     name: repair
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - hens
                         - laying hens
@@ -5735,7 +5735,7 @@ OntologyNode:
                     name: reproduction
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     definition: The collection, organization, and analysis of information to increase understanding of a topic or issue.
                     examples:
                         - experiment
@@ -5748,7 +5748,7 @@ OntologyNode:
                     name: research
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - conserve
                         - defend
@@ -5761,7 +5761,7 @@ OntologyNode:
                     name: securing
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - choose
                         - select
@@ -5769,21 +5769,21 @@ OntologyNode:
                     name: selection
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - share
                         - sharing
                     name: sharing
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - stabilization
                         - stabilize
                     name: stabilization
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - delay
                         - hamper
@@ -5794,7 +5794,7 @@ OntologyNode:
                     name: stalling
                     polarity: -1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - begin
                         - commence
@@ -5803,7 +5803,7 @@ OntologyNode:
                     name: start
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - continue
                         - exist
@@ -5812,7 +5812,7 @@ OntologyNode:
                     name: stay_or_remain
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - prop up
                         - shore up
@@ -5820,14 +5820,14 @@ OntologyNode:
                     name: strengthening
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - monitor
                         - surveil
                     name: surveilance
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - count
                         - enumerate
@@ -5835,10 +5835,10 @@ OntologyNode:
                     name: tabulation
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     name: trade
                     children:
-                        - OntologyNode:
+                        - node:
                             patterns:
                                 - \bexports?\b
                             examples:
@@ -5846,7 +5846,7 @@ OntologyNode:
                             name: export
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             patterns:
                                 - \bimports?\b
                             examples:
@@ -5854,10 +5854,10 @@ OntologyNode:
                             name: import
                             polarity: 1
                             semantic type: event
-                - OntologyNode:
+                - node:
                     name: training
                     children:
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - agriculture training
                                 - pest control
@@ -5867,16 +5867,16 @@ OntologyNode:
                             name: agriculture_training
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - financial training
                             name: financial_training
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             name: humanitarian_training
                             children:
-                                - OntologyNode:
+                                - node:
                                     patterns:
                                         - (SPHERE)
                                     examples:
@@ -5886,13 +5886,13 @@ OntologyNode:
                                     name: emergency_preparedness_training
                                     polarity: 1
                                     semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - medical training
                             name: medical_training
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - abilities
                                 - advice
@@ -5950,7 +5950,7 @@ OntologyNode:
                             name: training
                             polarity: 1
                             semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - buy
                         - food transaction
@@ -5965,7 +5965,7 @@ OntologyNode:
                     name: transaction
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - modernize
                         - reform
@@ -5973,7 +5973,7 @@ OntologyNode:
                     name: transformation
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - airborne
                         - community spread
@@ -5984,10 +5984,10 @@ OntologyNode:
                     name: transmission
                     polarity: -1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     name: transportation
                     children:
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - air travel
                                 - commercial transportation
@@ -5995,7 +5995,7 @@ OntologyNode:
                             name: commercial_transportation
                             polarity: 1
                             semantic type: event
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - commute
                                 - personal transportation
@@ -6003,7 +6003,7 @@ OntologyNode:
                             name: personal_transportation
                             polarity: 1
                             semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - journey
                         - travel
@@ -6012,7 +6012,7 @@ OntologyNode:
                     name: travel
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - cast ballot
                         - elect
@@ -6020,24 +6020,24 @@ OntologyNode:
                     name: voting
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - undermine
                         - weaken
                     name: weakening
                     polarity: -1
                     semantic type: event
-        - OntologyNode:
+        - node:
             name: property
             children:
-                - OntologyNode:
+                - node:
                     examples:
                         - accountability
                         - responsibility
                     name: accountability
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - affordable
                         - cost-effective
@@ -6046,7 +6046,7 @@ OntologyNode:
                     name: affordability
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - aftermath
                         - fallout
@@ -6058,20 +6058,20 @@ OntologyNode:
                     name: aftermath
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - allegiance
                         - loyalty
                     name: allegiance
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - availability
                     name: availability
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - chronic
                         - endemic
@@ -6089,7 +6089,7 @@ OntologyNode:
                     name: chronic
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     definition: relating to ordinary citizens and their concerns
                     examples:
                         - citizen
@@ -6098,7 +6098,7 @@ OntologyNode:
                     name: civic
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - awareness
                         - clarity
@@ -6109,14 +6109,14 @@ OntologyNode:
                     name: common_understanding
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - condition
                         - conditions
                     name: condition
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - absorptive capacity
                         - adaptive capacity
@@ -6135,20 +6135,20 @@ OntologyNode:
                     name: coping_capacities
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - diversity
                     name: diversity
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - domestic
                         - internal
                     name: domestic
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - antibiotic resistance
                         - antimicrobial resistance
@@ -6165,19 +6165,19 @@ OntologyNode:
                     name: drug_resistance
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - efficiency
                     name: efficiency
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - exotic breeds
                     name: exotic_breeds
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - equality
                         - equity
@@ -6186,7 +6186,7 @@ OntologyNode:
                     name: fairness
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - bilateral
                         - external aid
@@ -6197,23 +6197,23 @@ OntologyNode:
                     name: foreign
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     name: geographic_resolution
                     children:
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - global
                                 - world
                             name: global
                             polarity: 1
                             semantic type: property
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - international
                             name: international
                             polarity: 1
                             semantic type: property
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - city
                                 - local
@@ -6221,7 +6221,7 @@ OntologyNode:
                             name: local
                             polarity: 1
                             semantic type: property
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - nation
                                 - national
@@ -6229,7 +6229,7 @@ OntologyNode:
                             name: national
                             polarity: 1
                             semantic type: entity
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - kebele
                                 - provincial
@@ -6238,7 +6238,7 @@ OntologyNode:
                             name: sub-national
                             polarity: 1
                             semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - commercial breeds
                         - crossbred
@@ -6258,13 +6258,13 @@ OntologyNode:
                     name: hybrid_breeds
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - hydroponic
                     name: hydroponic
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - dangerous
                         - insecure
@@ -6273,13 +6273,13 @@ OntologyNode:
                     name: insecurity
                     polarity: -1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - instability
                     name: instability
                     polarity: -1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - constitutional
                         - constitutionality
@@ -6288,19 +6288,19 @@ OntologyNode:
                     name: legality
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - nonutilization
                     name: nonutilization
                     polarity: -1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - peaceful
                     name: peaceful
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - choice
                         - preference
@@ -6309,7 +6309,7 @@ OntologyNode:
                     name: preference
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - action
                         - contingency planning
@@ -6332,7 +6332,7 @@ OntologyNode:
                     name: preparedness
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     patterns:
                         - \b([Cc]osts?|[Pp]rices?)\b
                     examples:
@@ -6354,13 +6354,13 @@ OntologyNode:
                     name: price_or_cost
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - private
                     name: private
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - egg productivity
                         - performance
@@ -6369,20 +6369,20 @@ OntologyNode:
                     name: productivity
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - public
                     name: public
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - feed quality
                         - quality
                     name: quality
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - resilience
                         - resiliency
@@ -6390,7 +6390,7 @@ OntologyNode:
                     name: resilience
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - land rights
                         - land tenure
@@ -6398,13 +6398,13 @@ OntologyNode:
                     name: right_to_use
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - risk
                     name: risk
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - cycles
                         - delayed
@@ -6427,20 +6427,20 @@ OntologyNode:
                     name: seasonality
                     polarity: 1
                     semantic type: event
-                - OntologyNode:
+                - node:
                     examples:
                         - safety
                         - security
                     name: security
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - social
                     name: social
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     definition: Being unlikely to move or change.
                     examples:
                         - order
@@ -6448,7 +6448,7 @@ OntologyNode:
                     name: stability
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - affinity
                         - camaraderie
@@ -6459,7 +6459,7 @@ OntologyNode:
                     name: support
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - agricultural surplus
                         - egg surplus
@@ -6470,28 +6470,28 @@ OntologyNode:
                     name: surplus
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - sustainability
                         - sustainable
                     name: sustainable
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - makeshift
                         - temporary
                     name: temporary
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - openness
                         - transparency
                     name: transparency
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - lack
                         - paucity
@@ -6503,7 +6503,7 @@ OntologyNode:
                     name: unavailability
                     polarity: -1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     definition: An epistemic situation involving imperfect or unknown information.
                     examples:
                         - uncertainty
@@ -6511,13 +6511,13 @@ OntologyNode:
                     name: uncertainty
                     polarity: -1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - utilization
                     name: utilization
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - precarious
                         - tumult
@@ -6529,13 +6529,13 @@ OntologyNode:
                     name: variability
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - violent
                     name: violent
                     polarity: 1
                     semantic type: property
-                - OntologyNode:
+                - node:
                     examples:
                         - fragile
                         - fragility

--- a/CompositionalOntology_metadata.yml
+++ b/CompositionalOntology_metadata.yml
@@ -8,6 +8,7 @@ node:
                     name: agriculture
                     children:
                         - node:
+                            name: animal_feed
                             examples:
                                 - additives
                                 - amounts
@@ -48,10 +49,10 @@ node:
                                 - rations
                                 - replacement
                                 - supplementation
-                            name: animal_feed
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: animal_science
                             examples:
                                 - agricultural science
                                 - agriculture organization
@@ -76,13 +77,13 @@ node:
                                 - veterinary medicine
                                 - veterinary microbiology
                                 - veterinary science
-                            name: animal_science
                             polarity: 1
                             semantic type: event
                         - node:
                             name: crop
                             children:
                                 - node:
+                                    name: cereals
                                     definition: A grass cultivated for the edible parts of its grain.
                                     examples:
                                         - barley
@@ -91,16 +92,16 @@ node:
                                         - sorghum
                                         - tef
                                         - wheat
-                                    name: cereals
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: crop_land
                                     examples:
                                         - crop land
-                                    name: crop_land
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: crops
                                     examples:
                                         - cereals
                                         - crop
@@ -120,83 +121,83 @@ node:
                                         - staple
                                         - staple crops
                                         - tree crops
-                                    name: crops
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: fodder
                                     examples:
                                         - fodder
-                                    name: fodder
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: maize
                                     examples:
                                         - maize
                                         - maize grain
                                         - maize meal
                                         - white maize
                                         - yellow maize
-                                    name: maize
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: major_crops
                                     examples:
                                         - major crops
-                                    name: major_crops
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: other_crops
                                     examples:
                                         - other crops
-                                    name: other_crops
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: pulses
                                     examples:
                                         - beans
                                         - lentils
                                         - peas
                                         - pulses
-                                    name: pulses
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: sorghum
                                     examples:
                                         - red sorghum
                                         - sorghum
                                         - sorghum crops
                                         - white sorghum
-                                    name: sorghum
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: standing_crops
                                     examples:
                                         - standing crops
-                                    name: standing_crops
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: staple_crops
                                     examples:
                                         - staple crops
-                                    name: staple_crops
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: tree_crops
                                     examples:
                                         - tree crops
-                                    name: tree_crops
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: tubers
                                     examples:
                                         - cassava
                                         - potato
                                         - sweet potato
                                         - tubers
-                                    name: tubers
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: vegetables
                                     definition: vegetable crops and food
                                     examples:
                                         - beets
@@ -205,10 +206,10 @@ node:
                                         - lettuce
                                         - tomato
                                         - vegetables
-                                    name: vegetables
                                     polarity: 1
                                     semantic type: entity
                         - node:
+                            name: dairy
                             examples:
                                 - cheese
                                 - contract farming
@@ -229,35 +230,35 @@ node:
                                 - processors
                                 - producing
                                 - specialized dairy
-                            name: dairy
                             polarity: 1
                             semantic type: event
                         - node:
                             name: disease
                             children:
                                 - node:
+                                    name: crop_disease
                                     examples:
                                         - blight
                                         - crop disease
-                                    name: crop_disease
                                     polarity: -1
                                     semantic type: event
                                 - node:
+                                    name: livestock_disease
                                     examples:
                                         - livestock disease
-                                    name: livestock_disease
                                     polarity: -1
                                     semantic type: event
                                 - node:
+                                    name: poultry_disease
                                     examples:
                                         - chicken disease
                                         - colibacillosis
                                         - coryza
                                         - poultry disease
-                                    name: poultry_disease
                                     polarity: 1
                                     semantic type: event
                                 - node:
+                                    name: veterinary_care
                                     examples:
                                         - veterinarian
                                         - veterinarians
@@ -270,10 +271,10 @@ node:
                                         - veterinary science
                                         - veterinary service
                                         - veterinary services
-                                    name: veterinary_care
                                     polarity: 1
                                     semantic type: event
                         - node:
+                            name: livestock_nonpoultry
                             definition: Domesticated animals raised for their labor or to produce commodities such as milk, meat, eggs, fur, leather, or wool.
                             examples:
                                 - beef
@@ -295,13 +296,13 @@ node:
                                 - oxen
                                 - pigs
                                 - sheep
-                            name: livestock_nonpoultry
                             polarity: 1
                             semantic type: event
                         - node:
                             name: pest
                             children:
                                 - node:
+                                    name: animal_pests
                                     examples:
                                         - few swarms
                                         - fleas
@@ -325,38 +326,38 @@ node:
                                         - swarms
                                         - ticks
                                         - worms
-                                    name: animal_pests
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: army_worm
                                     examples:
                                         - army worm
-                                    name: army_worm
                                     polarity: -1
                                     semantic type: event
                                 - node:
                                     name: locust
                                     children:
                                         - node:
+                                            name: desert_locust
                                             examples:
                                                 - desert locust
-                                            name: desert_locust
                                             polarity: 1
                                             semantic type: entity
                                         - node:
                                             name: gregarious
                                             children:
                                                 - node:
+                                                    name: hopper_band
                                                     patterns:
                                                         - (hopper\s+band)|(bands?\s+of\s+hoppers)
                                                     examples:
                                                         - bands of hoppers
                                                         - immature
                                                         - locust hopper groups
-                                                    name: hopper_band
                                                     polarity: -1
                                                     semantic type: event
                                                 - node:
+                                                    name: locust_swarm
                                                     patterns:
                                                         - (locust\s+swarm)|(swarms?\s+of\s+locust)
                                                         - \bDL\b
@@ -367,40 +368,40 @@ node:
                                                         - locust swarm
                                                         - mature maturation
                                                         - swarm
-                                                    name: locust_swarm
                                                     polarity: -1
                                                     semantic type: event
                                         - node:
+                                            name: locust_eggs
                                             examples:
                                                 - locust eggs
-                                            name: locust_eggs
                                             polarity: -1
                                             semantic type: event
                                         - node:
                                             name: solitary
                                             children:
                                                 - node:
+                                                    name: solitary_hopper
                                                     examples:
                                                         - hopper
                                                         - immature
                                                         - instar
                                                         - solitarious hopper
                                                         - solitary
-                                                    name: solitary_hopper
                                                     polarity: -1
                                                     semantic type: event
                                                 - node:
+                                                    name: solitary_locust
                                                     examples:
                                                         - mature
                                                         - solitarious adult locust
                                                         - solitary locust
-                                                    name: solitary_locust
                                                     polarity: -1
                                                     semantic type: event
                         - node:
                             name: poultry
                             children:
                                 - node:
+                                    name: backyard_poultry_farming
                                     examples:
                                         - ancestors
                                         - backyard
@@ -427,19 +428,19 @@ node:
                                         - traditional system
                                         - traditional systems
                                         - yard
-                                    name: backyard_poultry_farming
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: bird_condition_healthy
                                     examples:
                                         - healthy birds
                                         - live birds
                                         - new birds
                                         - vaccinated birds
-                                    name: bird_condition_healthy
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: bird_condition_sick
                                     examples:
                                         - affected birds
                                         - avian pathology
@@ -461,10 +462,10 @@ node:
                                         - sick animals
                                         - sick birds
                                         - sick chickens
-                                    name: bird_condition_sick
                                     polarity: -1
                                     semantic type: entity
                                 - node:
+                                    name: broiler_chickens
                                     examples:
                                         - broiler
                                         - broiler chickens
@@ -474,10 +475,10 @@ node:
                                         - commercial lines
                                         - kuroiler
                                         - meat chickens
-                                    name: broiler_chickens
                                     polarity: 1
                                     semantic type: event
                                 - node:
+                                    name: cockerel
                                     examples:
                                         - cock
                                         - cockerel
@@ -486,10 +487,10 @@ node:
                                         - male chicken
                                         - rooster
                                         - stud
-                                    name: cockerel
                                     polarity: 1
                                     semantic type: event
                                 - node:
+                                    name: day_old_chicks
                                     examples:
                                         - DOC
                                         - babies
@@ -503,10 +504,10 @@ node:
                                         - hatcheries
                                         - nests
                                         - offspring
-                                    name: day_old_chicks
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: egg
                                     examples:
                                         - clutch
                                         - egg clutch
@@ -522,10 +523,10 @@ node:
                                         - shell thickness
                                         - total egg
                                         - yolk
-                                    name: egg
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: flock_size
                                     examples:
                                         - backyard flocks
                                         - base situation
@@ -543,10 +544,10 @@ node:
                                         - small flock
                                         - small flocks
                                         - whole flock
-                                    name: flock_size
                                     polarity: 1
                                     semantic type: event
                                 - node:
+                                    name: fowl
                                     examples:
                                         - domestic ducks
                                         - domestic fowl
@@ -569,10 +570,10 @@ node:
                                         - swan
                                         - waterfowl
                                         - wild bird
-                                    name: fowl
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: indigenous_breeds
                                     examples:
                                         - backyard chickens
                                         - backyard flocks
@@ -593,10 +594,10 @@ node:
                                         - scavenging chickens
                                         - traditional breeds
                                         - traditional chickens
-                                    name: indigenous_breeds
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: laying_hens
                                     examples:
                                         - brooder
                                         - brooders
@@ -614,18 +615,18 @@ node:
                                         - mothers
                                         - rearers
                                         - spent hens
-                                    name: laying_hens
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: poultry
                                     examples:
                                         - chicken
                                         - egg
                                         - poultry
-                                    name: poultry
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: poultry_sector
                                     examples:
                                         - commercial farms
                                         - commercial producers
@@ -646,19 +647,18 @@ node:
                                         - poultry sector
                                         - slaughterhouses
                                         - veterinary department
-                                    name: poultry_sector
                                     polarity: 1
                                     semantic type: event
                 - node:
+                    name: civil_liberties
                     examples:
                         - civil liberties
-                    name: civil_liberties
                     polarity: 1
                     semantic type: entity
                 - node:
+                    name: civil_society
                     examples:
                         - civil society
-                    name: civil_society
                     polarity: 1
                     semantic type: entity
                 - node:
@@ -668,6 +668,7 @@ node:
                             name: conflict
                             children:
                                 - node:
+                                    name: armed_conflict
                                     examples:
                                         - acts
                                         - armed
@@ -693,10 +694,10 @@ node:
                                         - threats
                                         - violent conflict
                                         - wars
-                                    name: armed_conflict
                                     polarity: 1
                                     semantic type: event
                                 - node:
+                                    name: crime
                                     examples:
                                         - abduction
                                         - assault
@@ -742,10 +743,10 @@ node:
                                         - vandalism
                                         - violations
                                         - violent crime
-                                    name: crime
                                     polarity: -1
                                     semantic type: event
                                 - node:
+                                    name: discontent
                                     examples:
                                         - alienation
                                         - anger
@@ -766,10 +767,10 @@ node:
                                         - resentment
                                         - sentiments
                                         - unrest
-                                    name: discontent
                                     polarity: -1
                                     semantic type: event
                                 - node:
+                                    name: hostility
                                     examples:
                                         - armed clash
                                         - armed groups
@@ -795,10 +796,10 @@ node:
                                         - violence
                                         - violence in the region
                                         - war
-                                    name: hostility
                                     polarity: -1
                                     semantic type: event
                                 - node:
+                                    name: tension
                                     examples:
                                         - adversity
                                         - burden
@@ -818,10 +819,10 @@ node:
                                         - stalemate
                                         - stress
                                         - threatening
-                                    name: tension
                                     polarity: -1
                                     semantic type: event
                         - node:
+                            name: early_warning
                             examples:
                                 - alarm
                                 - alerts
@@ -836,32 +837,32 @@ node:
                                 - risk reduction
                                 - safety
                                 - warning
-                            name: early_warning
                             polarity: 1
                             semantic type: event
                         - node:
                             name: environmental
                             children:
                                 - node:
+                                    name: drought
                                     definition: A prolonged shortage in the water supply.
                                     examples:
                                         - drought
                                         - droughts
                                         - low rainfall
-                                    name: drought
                                     polarity: -1
                                     semantic type: event
                                 - node:
+                                    name: earthquake
                                     examples:
                                         - aftershock
                                         - earthquake
                                         - earthquakes
                                         - tremor
                                         - tremors
-                                    name: earthquake
                                     polarity: -1
                                     semantic type: event
                                 - node:
+                                    name: environmental_degradation
                                     examples:
                                         - acidification
                                         - deltas
@@ -876,20 +877,20 @@ node:
                                         - salinity
                                         - salinization
                                         - sedimentation
-                                    name: environmental_degradation
                                     polarity: -1
                                     semantic type: event
                                 - node:
+                                    name: flood
                                     examples:
                                         - flash flood
                                         - flood
                                         - flooding
                                         - storm surge
                                         - tsunami
-                                    name: flood
                                     polarity: -1
                                     semantic type: event
                                 - node:
+                                    name: natural_disaster
                                     examples:
                                         - cyclones
                                         - episodes
@@ -909,60 +910,60 @@ node:
                                         - typhoons
                                         - weather
                                         - winds
-                                    name: natural_disaster
                                     polarity: -1
                                     semantic type: event
                                 - node:
+                                    name: storm
                                     examples:
                                         - cyclone
                                         - hurricane
                                         - landfall
                                         - storm
-                                    name: storm
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: volcanic_eruption
                                     examples:
                                         - volcanic eruption
                                         - volcano
-                                    name: volcanic_eruption
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: wildfire
                                     examples:
                                         - wild fire
                                         - wildfire
-                                    name: wildfire
                                     polarity: -1
                                     semantic type: event
                         - node:
+                            name: epidemic
                             definition: The rapid spread of disease to a large population in a short amount of time.
                             examples:
                                 - disease
                                 - epidemic
                                 - global pandemic
                                 - pandemic
-                            name: epidemic
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: famine
                             examples:
                                 - famine
                                 - hunger
                                 - starvation
-                            name: famine
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: recession
                             examples:
                                 - depression
                                 - economic crisis
                                 - financial crisis
                                 - recession
-                            name: recession
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: shocks
                             examples:
                                 - adverse shocks
                                 - catastrophe
@@ -976,37 +977,37 @@ node:
                                 - other shocks
                                 - shocks
                                 - worse outcomes
-                            name: shocks
                             polarity: 1
                             semantic type: event
                 - node:
+                    name: cultural_norms
                     examples:
                         - beliefs
                         - cultural norms
                         - social norms
                         - traditions
-                    name: cultural_norms
                     polarity: 1
                     semantic type: entity
                 - node:
+                    name: curfew
                     examples:
                         - curfew
-                    name: curfew
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: discrimination
                     examples:
                         - discrimination
                         - exclusion
                         - racism
                         - stratification
-                    name: discrimination
                     polarity: -1
                     semantic type: event
                 - node:
                     name: economy
                     children:
                         - node:
+                            name: assets
                             examples:
                                 - assets
                                 - holdings
@@ -1015,16 +1016,16 @@ node:
                                 - parcels
                                 - property
                                 - wealth
-                            name: assets
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: budget
                             examples:
                                 - budget
-                            name: budget
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: commerce
                             examples:
                                 - GDP
                                 - GNP
@@ -1054,19 +1055,19 @@ node:
                                 - several markets
                                 - stock market
                                 - urban markets
-                            name: commerce
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: commercial_enterprise
                             examples:
                                 - business
                                 - commercial enterprise
                                 - company
                                 - corporation
-                            name: commercial_enterprise
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: commercial_farmers
                             examples:
                                 - commercial farm
                                 - commercial farming
@@ -1085,34 +1086,34 @@ node:
                                 - outgrowers
                                 - plantation
                                 - ranch
-                            name: commercial_farmers
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: competition
                             examples:
                                 - competition
-                            name: competition
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: currency
                             examples:
                                 - cash
                                 - currency
                                 - dollar
                                 - money
                                 - usd
-                            name: currency
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: debt
                             examples:
                                 - debt
                                 - deficit
                                 - loan
-                            name: debt
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: economy
                             examples:
                                 - comparative advantages
                                 - economic benefits
@@ -1143,10 +1144,10 @@ node:
                                 - potential benefits
                                 - social benefits
                                 - social value
-                            name: economy
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: exchange_rate
                             examples:
                                 - card
                                 - consumer prices
@@ -1164,20 +1165,20 @@ node:
                                 - reserve
                                 - stocking rates
                                 - vat
-                            name: exchange_rate
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: expense
                             examples:
                                 - charge
                                 - expense
                                 - fee
                                 - payment
                                 - rent
-                            name: expense
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: finance
                             examples:
                                 - assets
                                 - award
@@ -1219,10 +1220,10 @@ node:
                                 - physical capital
                                 - social capital
                                 - working capital
-                            name: finance
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: income
                             examples:
                                 - compensation
                                 - earnings
@@ -1233,10 +1234,10 @@ node:
                                 - royalties
                                 - salary
                                 - wages
-                            name: income
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: labor
                             examples:
                                 - casual labour
                                 - decent work
@@ -1252,18 +1253,18 @@ node:
                                 - work
                                 - workload
                                 - workplace
-                            name: labor
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: livelihood
                             examples:
                                 - employment
                                 - job
                                 - livelihood
-                            name: livelihood
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: marketing
                             examples:
                                 - boxes
                                 - brands
@@ -1293,10 +1294,10 @@ node:
                                 - transporters
                                 - vendors
                                 - wholesalers
-                            name: marketing
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: marketplace
                             examples:
                                 - bazaar
                                 - grocer
@@ -1314,10 +1315,10 @@ node:
                                 - supermarket
                                 - vendor
                                 - wet market
-                            name: marketplace
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: payment
                             examples:
                                 - disbursement
                                 - drawdown
@@ -1325,24 +1326,24 @@ node:
                                 - payout
                                 - remittance
                                 - stipend
-                            name: payment
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: purchasing_power
                             examples:
                                 - purchasing power
-                            name: purchasing_power
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: small_businesses
                             examples:
                                 - entrepreneurs
                                 - entrepreneurship
                                 - small businesses
-                            name: small_businesses
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: small_farmers
                             examples:
                                 - farmers
                                 - fields
@@ -1367,10 +1368,10 @@ node:
                                 - subsistence farmers
                                 - traditional sector
                                 - villagers
-                            name: small_farmers
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: taxes
                             examples:
                                 - duties
                                 - revenue
@@ -1379,26 +1380,26 @@ node:
                                 - tariff
                                 - tax
                                 - taxes
-                            name: taxes
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: unemployment
                             examples:
                                 - unemployment
-                            name: unemployment
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: workforce
                             examples:
                                 - labor
                                 - professionals
                                 - staff
                                 - worker
                                 - workforce
-                            name: workforce
                             polarity: 1
                             semantic type: event
                 - node:
+                    name: education
                     examples:
                         - courses
                         - curriculum
@@ -1410,13 +1411,13 @@ node:
                         - schooling
                         - trainings
                         - tutoring
-                    name: education
                     polarity: 1
                     semantic type: event
                 - node:
                     name: entity
                     children:
                         - node:
+                            name: african_governments
                             examples:
                                 - african countries
                                 - african governments
@@ -1424,10 +1425,10 @@ node:
                                 - african nations
                                 - african societies
                                 - african states
-                            name: african_governments
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: al-shabaab
                             examples:
                                 - Harakat al-Shabaab al-Mujahideen
                                 - Mujahideen Youth Movement
@@ -1435,10 +1436,10 @@ node:
                                 - al-shabaab
                                 - al-shabab
                                 - hsm
-                            name: al-shabaab
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: animal
                             examples:
                                 - animal
                                 - animal resources
@@ -1481,23 +1482,23 @@ node:
                                 - wild animals
                                 - wildlife
                                 - young animals
-                            name: animal
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: artifact
                             examples:
                                 - artifact
-                            name: artifact
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: border
                             examples:
                                 - border
                                 - land border
-                            name: border
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: drone
                             examples:
                                 - drone
                                 - drones
@@ -1506,10 +1507,10 @@ node:
                                 - unmanned aerial vehicle
                                 - unmanned air system
                                 - unmanned air vehicle
-                            name: drone
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: field_reports
                             examples:
                                 - chirps
                                 - climate information
@@ -1525,25 +1526,25 @@ node:
                                 - reports
                                 - satellite
                                 - weather data
-                            name: field_reports
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: gangs
                             examples:
                                 - gang
                                 - gangs
-                            name: gangs
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: geo-political_entity
                             examples:
                                 - GPE
                                 - city
                                 - nation
-                            name: geo-political_entity
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: government_entity
                             examples:
                                 - administration
                                 - administrations
@@ -1568,16 +1569,16 @@ node:
                                 - offices
                                 - organisation
                                 - prefecturates
-                            name: government_entity
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: hamas
                             examples:
                                 - hamas
-                            name: hamas
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: humanitarian_actors
                             examples:
                                 - agencies
                                 - aid
@@ -1612,17 +1613,17 @@ node:
                                 - unicef
                                 - unsom
                                 - unsom officer
-                            name: humanitarian_actors
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: indigenous_communities
                             examples:
                                 - indigenous communities
                                 - indigenous people
-                            name: indigenous_communities
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: international_organizations
                             examples:
                                 - global community
                                 - international agencies
@@ -1631,20 +1632,20 @@ node:
                                 - international organizations
                                 - ngo
                                 - ngos
-                            name: international_organizations
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: isil
                             examples:
                                 - isil
                                 - isis
-                            name: isil
                             polarity: 1
                             semantic type: entity
                         - node:
                             name: locations
                             children:
                                 - node:
+                                    name: city
                                     examples:
                                         - big cities
                                         - capitals
@@ -1657,49 +1658,49 @@ node:
                                         - urban centers
                                         - urban centre
                                         - urban markets
-                                    name: city
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: location
                                     examples:
                                         - city
                                         - country
                                         - geo-location
                                         - location
-                                    name: location
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: neighboring_country
                                     examples:
                                         - neighboring country
-                                    name: neighboring_country
                                     polarity: 1
                                     semantic type: entity
                         - node:
+                            name: lord's_resistance_army
                             examples:
                                 - lord's resistance army
                                 - lord's resistance movement
                                 - lra
-                            name: lord's_resistance_army
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: military_exercise
                             examples:
                                 - military exercise
                                 - military game
                                 - military maneuvers
-                            name: military_exercise
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: military_power
                             examples:
                                 - military
                                 - military force
                                 - military power
-                            name: military_power
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: multilateral_system
                             examples:
                                 - bilateral donors
                                 - development actors
@@ -1714,29 +1715,29 @@ node:
                                 - societies
                                 - trading partners
                                 - union
-                            name: multilateral_system
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: muslim_communities
                             examples:
                                 - islam
                                 - mosque
                                 - muslim communities
                                 - muslim world
                                 - muslims
-                            name: muslim_communities
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: nonstate_actors
                             examples:
                                 - external actors
                                 - external intervention
                                 - nonstate actors
                                 - other stakeholders
-                            name: nonstate_actors
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: opposition_party
                             examples:
                                 - opposition
                                 - opposition groups
@@ -1748,23 +1749,23 @@ node:
                                 - political adversary
                                 - political opponents
                                 - political rival
-                            name: opposition_party
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: organization
                             examples:
                                 - NGO
                                 - community based organization
                                 - community group
                                 - cooperative
                                 - organization
-                            name: organization
                             polarity: 1
                             semantic type: entity
                         - node:
                             name: people
                             children:
                                 - node:
+                                    name: academic
                                     examples:
                                         - academic
                                         - analyst
@@ -1782,19 +1783,19 @@ node:
                                         - sophomore
                                         - specialist
                                         - student
-                                    name: academic
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: activist
                                     examples:
                                         - activist
                                         - crowd
                                         - demonstrator
                                         - protester
-                                    name: activist
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: adults
                                     examples:
                                         - adult
                                         - elder
@@ -1802,10 +1803,10 @@ node:
                                         - men
                                         - senior citizen
                                         - women
-                                    name: adults
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: adviser
                                     examples:
                                         - adviser
                                         - advisor
@@ -1823,10 +1824,10 @@ node:
                                         - technicians
                                         - trainers
                                         - volunteers
-                                    name: adviser
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: child_or_youth
                                     examples:
                                         - adolescent
                                         - child
@@ -1837,16 +1838,16 @@ node:
                                         - teenager
                                         - young people
                                         - youth
-                                    name: child_or_youth
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: citizen
                                     examples:
                                         - citizen
-                                    name: citizen
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: criminal
                                     examples:
                                         - cartel
                                         - criminal
@@ -1856,10 +1857,10 @@ node:
                                         - smuggler
                                         - syndicate
                                         - warlord
-                                    name: criminal
                                     polarity: -1
                                     semantic type: entity
                                 - node:
+                                    name: detainee
                                     examples:
                                         - captive
                                         - detainee
@@ -1867,10 +1868,10 @@ node:
                                         - inmate
                                         - prisoner
                                         - slave
-                                    name: detainee
                                     polarity: -1
                                     semantic type: entity
                                 - node:
+                                    name: elites
                                     examples:
                                         - aristocracy
                                         - aristocrat
@@ -1879,10 +1880,10 @@ node:
                                         - lord
                                         - monarch
                                         - queen
-                                    name: elites
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: extremist
                                     examples:
                                         - VEO
                                         - crusader
@@ -1894,10 +1895,10 @@ node:
                                         - terrorist
                                         - vigilante
                                         - violent extremist organization
-                                    name: extremist
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: farm_worker
                                     examples:
                                         - cowherd
                                         - farm worker
@@ -1911,10 +1912,10 @@ node:
                                         - shepherd
                                         - smallholder
                                         - stockmen
-                                    name: farm_worker
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: government_worker
                                     examples:
                                         - ambassador
                                         - attorney general
@@ -1932,10 +1933,10 @@ node:
                                         - president
                                         - public official
                                         - senator
-                                    name: government_worker
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: health_worker
                                     examples:
                                         - CHW
                                         - community health worker
@@ -1945,10 +1946,10 @@ node:
                                         - nurse
                                         - nursing
                                         - physicians assistant
-                                    name: health_worker
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: household
                                     patterns:
                                         - household
                                     examples:
@@ -1966,26 +1967,26 @@ node:
                                         - poorest households
                                         - producing households
                                         - wealthier households
-                                    name: household
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: infant
                                     examples:
                                         - baby
                                         - infant
                                         - newborn
-                                    name: infant
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: landowner
                                     examples:
                                         - landholder
                                         - landlord
                                         - landowner
-                                    name: landowner
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: law_enforcement_officials
                                     examples:
                                         - law enforcement
                                         - local officials
@@ -1994,52 +1995,52 @@ node:
                                         - police forces
                                         - police officer
                                         - security officials
-                                    name: law_enforcement_officials
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: maternal
                                     examples:
                                         - maternal
                                         - mother
                                         - mothers
-                                    name: maternal
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: men
                                     examples:
                                         - husband
                                         - man
                                         - men
-                                    name: men
                                     polarity: 1
                                     semantic type: entity
                                 - node:
                                     name: migration
                                     children:
                                         - node:
+                                            name: displaced_person
                                             examples:
                                                 - IDP
                                                 - displaced person
                                                 - returnee
-                                            name: displaced_person
                                             polarity: 1
                                             semantic type: entity
                                         - node:
+                                            name: migrant
                                             examples:
                                                 - economic migrant
                                                 - migrant
-                                            name: migrant
                                             polarity: -1
                                             semantic type: entity
                                         - node:
+                                            name: refugee
                                             examples:
                                                 - asylum seeker
                                                 - refugee
                                                 - returnee
-                                            name: refugee
                                             polarity: 1
                                             semantic type: entity
                                 - node:
+                                    name: military_personnel
                                     examples:
                                         - admiral
                                         - armed forces
@@ -2056,16 +2057,16 @@ node:
                                         - regiment
                                         - soldier
                                         - troops
-                                    name: military_personnel
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: militia
                                     examples:
                                         - militia
-                                    name: militia
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: newsmedia
                                     examples:
                                         - anchor
                                         - blogger
@@ -2075,48 +2076,48 @@ node:
                                         - news anchor
                                         - newsmedia
                                         - reporter
-                                    name: newsmedia
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: observer
                                     examples:
                                         - observer
                                         - watchdog
-                                    name: observer
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: person_or_group
                                     examples:
                                         - community
                                         - group
                                         - person or group
                                         - society
                                         - village
-                                    name: person_or_group
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: rebels
                                     examples:
                                         - insurgents
                                         - militant group
                                         - rebel group
-                                    name: rebels
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: taskforce
                                     examples:
                                         - task force
                                         - taskforce
-                                    name: taskforce
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: voter
                                     examples:
                                         - voter
-                                    name: voter
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: women
                                     examples:
                                         - bride
                                         - female farmers
@@ -2128,27 +2129,27 @@ node:
                                         - woman
                                         - women
                                         - women farmers
-                                    name: women
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: young_adults
                                     examples:
                                         - young adults
                                         - young men
                                         - young women
-                                    name: young_adults
                                     polarity: 1
                                     semantic type: entity
                         - node:
+                            name: religious_entity
                             examples:
                                 - church
                                 - congregation
                                 - parish
                                 - seminary
-                            name: religious_entity
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: ruling_party
                             definition: 'note: in Kenya, the ruling party is the Jubilee party'
                             examples:
                                 - incumbent
@@ -2156,10 +2157,10 @@ node:
                                 - jubilee party
                                 - ruling coalition
                                 - ruling party
-                            name: ruling_party
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: rural_households
                             examples:
                                 - communes
                                 - farmlands
@@ -2179,10 +2180,10 @@ node:
                                 - rural sector
                                 - rural villages
                                 - subsistence
-                            name: rural_households
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: urban_households
                             examples:
                                 - cities
                                 - city
@@ -2198,10 +2199,10 @@ node:
                                 - urban populations
                                 - urban residents
                                 - urban settings
-                            name: urban_households
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: vehicle
                             examples:
                                 - SUV
                                 - aeroplane
@@ -2220,10 +2221,10 @@ node:
                                 - truck
                                 - van
                                 - vehicle
-                            name: vehicle
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: weapons
                             examples:
                                 - ammunition
                                 - explosives
@@ -2232,19 +2233,19 @@ node:
                                 - light weapons
                                 - small arms
                                 - weapons
-                            name: weapons
                             polarity: 1
                             semantic type: entity
                 - node:
                     name: environment
                     children:
                         - node:
+                            name: climate
                             examples:
                                 - climate
-                            name: climate
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: climate_change
                             examples:
                                 - changing climate
                                 - climate
@@ -2270,10 +2271,10 @@ node:
                                 - human activity
                                 - human factors
                                 - natural systems
-                            name: climate_change
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: ecology
                             examples:
                                 - biodiversity
                                 - ecology
@@ -2281,10 +2282,10 @@ node:
                                 - habitat
                                 - riparian
                                 - wildlife
-                            name: ecology
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: emissions
                             examples:
                                 - aerosol
                                 - aerosols
@@ -2303,16 +2304,16 @@ node:
                                 - thermocline
                                 - thermotolerance
                                 - tropospheric ozone
-                            name: emissions
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: environmental_impacts
                             examples:
                                 - environmental impacts
-                            name: environmental_impacts
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: forestry
                             examples:
                                 - afforestation
                                 - agroforestry
@@ -2334,10 +2335,10 @@ node:
                                 - timber
                                 - tree
                                 - vegetation
-                            name: forestry
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: higher_temperatures
                             examples:
                                 - climate changes
                                 - degrees
@@ -2353,28 +2354,28 @@ node:
                                 - temperature increases
                                 - temperatures
                                 - warmer temperatures
-                            name: higher_temperatures
                             polarity: 1
                             semantic type: event
                         - node:
                             name: meteorology
                             children:
                                 - node:
+                                    name: precipitation
                                     examples:
                                         - precipitation
                                         - rain
                                         - rainfall
                                         - storm
-                                    name: precipitation
                                     polarity: 1
                                     semantic type: event
                                 - node:
+                                    name: temperature
                                     examples:
                                         - temperature
-                                    name: temperature
                                     polarity: 1
                                     semantic type: event
                                 - node:
+                                    name: weather
                                     definition: The state of the atmosphere, describing the degree to which it is hot or cold, wet or dry, calm or stormy, clear or cloudy.
                                     examples:
                                         - climate variability
@@ -2388,13 +2389,13 @@ node:
                                         - weather systems
                                         - wet
                                         - wetter
-                                    name: weather
                                     polarity: 1
                                     semantic type: event
                         - node:
                             name: natural_resources
                             children:
                                 - node:
+                                    name: fossil_fuels
                                     definition: Fuels formed from natural processes, containing organic molecules, that release energy in combustion.
                                     examples:
                                         - carbon
@@ -2402,16 +2403,16 @@ node:
                                         - fossil fuels
                                         - natural gas
                                         - oil
-                                    name: fossil_fuels
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: groundwater
                                     examples:
                                         - groundwater
-                                    name: groundwater
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: land
                                     examples:
                                         - acreage
                                         - arable land
@@ -2420,10 +2421,10 @@ node:
                                         - land
                                         - land resources
                                         - plot
-                                    name: land
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: pasture
                                     definition: Land used for grazing by domesticated livestock.
                                     examples:
                                         - grazing
@@ -2431,18 +2432,18 @@ node:
                                         - pasture
                                         - rangeland
                                         - vegetation
-                                    name: pasture
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: soil
                                     examples:
                                         - leaching into the soil
                                         - soil
                                         - soil types
-                                    name: soil
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: water_bodies
                                     examples:
                                         - aqueduct
                                         - lake
@@ -2451,30 +2452,29 @@ node:
                                         - reservoir
                                         - river
                                         - water bodies
-                                    name: water_bodies
                                     polarity: 1
                                     semantic type: entity
                         - node:
+                            name: pollution
                             examples:
                                 - air pollution
                                 - contamination
                                 - greenhouse gas
                                 - land pollution
                                 - water pollution
-                            name: pollution
                             polarity: -1
                             semantic type: event
                 - node:
+                    name: ethnic_diversity
                     examples:
                         - ethnic diversity
                         - ethnic minorities
-                    name: ethnic_diversity
                     polarity: 1
                     semantic type: entity
                 - node:
+                    name: freedom
                     examples:
                         - freedom
-                    name: freedom
                     polarity: 1
                     semantic type: event
                 - node:
@@ -2484,6 +2484,7 @@ node:
                             name: agricultural
                             children:
                                 - node:
+                                    name: compound_feed
                                     examples:
                                         - compound feed
                                         - compound poultry feed
@@ -2491,10 +2492,10 @@ node:
                                         - micronutrients
                                         - oil cakes
                                         - supplemental feed
-                                    name: compound_feed
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: farm_equipment
                                     examples:
                                         - farm equipment
                                         - machinery
@@ -2503,10 +2504,10 @@ node:
                                         - row planter
                                         - tractor
                                         - winnower
-                                    name: farm_equipment
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: feed
                                     examples:
                                         - CSB
                                         - corn meal
@@ -2515,10 +2516,10 @@ node:
                                         - poultry feed
                                         - silage
                                         - soybean hulls
-                                    name: feed
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: fertilizer
                                     patterns:
                                         - \b(manure|fertilizers?|nitrogen)\b
                                     examples:
@@ -2530,10 +2531,10 @@ node:
                                         - phosphorous
                                         - potassium
                                         - urea
-                                    name: fertilizer
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: irrigation_equipment
                                     examples:
                                         - drip
                                         - electric pump
@@ -2544,10 +2545,10 @@ node:
                                         - sprinklers
                                         - treadle
                                         - water pumps
-                                    name: irrigation_equipment
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: meat
                                     examples:
                                         - animal production
                                         - beef
@@ -2604,10 +2605,10 @@ node:
                                         - turkeys
                                         - white meat
                                         - wild foods
-                                    name: meat
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: pesticide
                                     patterns:
                                         - \b(DDT|dicamba|round-up)\b
                                     examples:
@@ -2616,28 +2617,28 @@ node:
                                         - integrated pest management
                                         - organic
                                         - pesticide
-                                    name: pesticide
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: seed
                                     examples:
                                         - GMO
                                         - heirloom seed
                                         - improved seed
                                         - organic seed
                                         - seed
-                                    name: seed
                                     polarity: 1
                                     semantic type: entity
                         - node:
+                            name: construction_materials
                             examples:
                                 - concrete cement
                                 - construction materials
                                 - lumber
-                            name: construction_materials
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: education_supplies
                             examples:
                                 - chalkboard
                                 - education supplies
@@ -2645,10 +2646,10 @@ node:
                                 - pencil
                                 - smartboard
                                 - textbooks
-                            name: education_supplies
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: food
                             examples:
                                 - bread
                                 - breakfast
@@ -2682,18 +2683,18 @@ node:
                                 - spices
                                 - sweet potatoes
                                 - tomatoes
-                            name: food
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: fuel
                             examples:
                                 - fuel
                                 - gas
                                 - oil
-                            name: fuel
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: medical_supplies
                             examples:
                                 - bandages
                                 - bed
@@ -2701,10 +2702,10 @@ node:
                                 - medical supplies
                                 - respirator
                                 - ventilator
-                            name: medical_supplies
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: medicine
                             examples:
                                 - antibiotics
                                 - antimicrobial
@@ -2722,10 +2723,10 @@ node:
                                 - steroid
                                 - tetracycline
                                 - therapeutic
-                            name: medicine
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: minerals
                             examples:
                                 - aluminium
                                 - aluminum
@@ -2738,10 +2739,10 @@ node:
                                 - ore
                                 - silver
                                 - zinc
-                            name: minerals
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: potable_water
                             examples:
                                 - clean water
                                 - drinking water
@@ -2749,10 +2750,10 @@ node:
                                 - potable water
                                 - safe water
                                 - water quality
-                            name: potable_water
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: protein_foods
                             examples:
                                 - alfalfa
                                 - bean
@@ -2777,15 +2778,14 @@ node:
                                 - tilapia
                                 - yoghurt
                                 - yogurt
-                            name: protein_foods
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: water
                             examples:
                                 - H20
                                 - aqua
                                 - water
-                            name: water
                             polarity: 1
                             semantic type: entity
                 - node:
@@ -2798,6 +2798,7 @@ node:
                                     name: corrupt_policy
                                     children:
                                         - node:
+                                            name: cronyism
                                             examples:
                                                 - cronyism
                                                 - favoritism
@@ -2806,20 +2807,20 @@ node:
                                                 - policy favoritism
                                                 - political clientelist network
                                                 - political patronage
-                                            name: cronyism
                                             polarity: 1
                                             semantic type: event
                                         - node:
+                                            name: illicit_political_financing
                                             examples:
                                                 - campaign financing irregularities
                                                 - conflict of interest
                                                 - illegal contributions
                                                 - illicit contributions
                                                 - illicit political financing
-                                            name: illicit_political_financing
                                             polarity: 1
                                             semantic type: entity
                                         - node:
+                                            name: parliamentary_corruption
                                             examples:
                                                 - bribery
                                                 - corrupt parliamentary oversight
@@ -2829,10 +2830,10 @@ node:
                                                 - parliamentary vote selling
                                                 - rent extraction
                                                 - rent seeking
-                                            name: parliamentary_corruption
                                             polarity: 1
                                             semantic type: entity
                                 - node:
+                                    name: election_manipulation
                                     examples:
                                         - ballot burning
                                         - ballot stuffing
@@ -2849,10 +2850,10 @@ node:
                                         - voter fraud
                                         - voter intimidation
                                         - voter oppression
-                                    name: election_manipulation
                                     polarity: 1
                                     semantic type: event
                                 - node:
+                                    name: government_corruption
                                     examples:
                                         - arbitrary arrests
                                         - bribery
@@ -2860,46 +2861,46 @@ node:
                                         - disappearances
                                         - extrajudicial killings
                                         - impunity
-                                    name: government_corruption
                                     polarity: 1
                                     semantic type: event
                         - node:
+                            name: decentralization
                             examples:
                                 - decentralization
                                 - decentralize
-                            name: decentralization
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: diplomatic_relations
                             examples:
                                 - foreign affairs
                                 - international affairs
                                 - international relations
                                 - international security
-                            name: diplomatic_relations
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: election
                             examples:
                                 - ballot
                                 - caucus
                                 - election
                                 - referendum
                                 - voting
-                            name: election
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: election_process
                             examples:
                                 - election cycle
                                 - election process
                                 - electoral cycle
                                 - electoral process
                                 - electoral system
-                            name: election_process
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: foreign_policy
                             examples:
                                 - diplomats
                                 - foreign affairs
@@ -2908,10 +2909,10 @@ node:
                                 - foreign relations
                                 - international security
                                 - political science
-                            name: foreign_policy
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: government_program
                             examples:
                                 - census
                                 - policy
@@ -2919,10 +2920,10 @@ node:
                                 - psnp
                                 - safety net
                                 - social security
-                            name: government_program
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: judicial_system
                             examples:
                                 - court system
                                 - courthouse
@@ -2930,10 +2931,10 @@ node:
                                 - judiciary
                                 - supreme court
                                 - tribunal
-                            name: judicial_system
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: legislation
                             examples:
                                 - act
                                 - appropriate policies
@@ -2955,17 +2956,17 @@ node:
                                 - regulatory frameworks
                                 - schedules
                                 - sector policies
-                            name: legislation
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: political_power
                             examples:
                                 - political influence
                                 - political power
-                            name: political_power
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: political_system
                             examples:
                                 - authoritarianism
                                 - autocracy
@@ -2978,33 +2979,33 @@ node:
                                 - reforms
                                 - regime
                                 - reign
-                            name: political_system
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: polling_stations
                             examples:
                                 - polling staff
                                 - polling station
                                 - polling stations
-                            name: polling_stations
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: sanction
                             definition: A restriction on trade, or measures by a country on a state or individual intended to elicit a change in their behavior.
                             examples:
                                 - sanction
-                            name: sanction
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: state_collapse
                             examples:
                                 - failed states
                                 - state collapse
                                 - state failure
-                            name: state_collapse
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: state_power
                             examples:
                                 - central authority
                                 - congressional power
@@ -3016,35 +3017,35 @@ node:
                                 - state institutions
                                 - state power
                                 - state-building
-                            name: state_power
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: transition_of_power
                             examples:
                                 - government change
-                            name: transition_of_power
                             polarity: 1
                             semantic type: event
                 - node:
                     name: health
                     children:
                         - node:
+                            name: antibody
                             examples:
                                 - antibodies
                                 - antibody
                                 - antigens
-                            name: antibody
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: biometrics
                             examples:
                                 - DNA
                                 - biometrics
                                 - fingerprint
-                            name: biometrics
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: case_volume
                             patterns:
                                 - \b(case\s+volume)\b
                                 - \b(new\s+cases)\b
@@ -3056,20 +3057,20 @@ node:
                                 - reported cases
                                 - severe cases
                                 - suspected cases
-                            name: case_volume
                             polarity: -1
                             semantic type: event
                         - node:
                             name: disease
                             children:
                                 - node:
+                                    name: AIDS
                                     examples:
                                         - aids
                                         - hiv
-                                    name: AIDS
                                     polarity: -1
                                     semantic type: event
                                 - node:
+                                    name: COVID
                                     patterns:
                                         - (COVID|covid|SARS-CoV)
                                         - corona(\s+)?virus
@@ -3078,17 +3079,17 @@ node:
                                         - coronavirus
                                         - novel coronavirus
                                         - virus
-                                    name: COVID
                                     polarity: -1
                                     semantic type: event
                                 - node:
+                                    name: flu
                                     examples:
                                         - flu
                                         - influenza
-                                    name: flu
                                     polarity: -1
                                     semantic type: event
                                 - node:
+                                    name: illness
                                     examples:
                                         - anaemia
                                         - cancer
@@ -3115,16 +3116,16 @@ node:
                                         - tuberculosis
                                         - vessels
                                         - zika
-                                    name: illness
                                     polarity: -1
                                     semantic type: event
                                 - node:
+                                    name: malaria
                                     examples:
                                         - malaria
-                                    name: malaria
                                     polarity: -1
                                     semantic type: event
                         - node:
+                            name: gene
                             examples:
                                 - alleles
                                 - carriers
@@ -3148,18 +3149,18 @@ node:
                                 - mutations
                                 - phenotypes
                                 - snps
-                            name: gene
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: healthcare
                             examples:
                                 - health
                                 - healthcare
                                 - medical
-                            name: healthcare
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: hygiene_materials
                             examples:
                                 - PPE
                                 - face covering
@@ -3168,17 +3169,17 @@ node:
                                 - masks
                                 - personal protective equipment
                                 - soap
-                            name: hygiene_materials
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: injury
                             examples:
                                 - injury
                                 - wound
-                            name: injury
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: laboratory_testing
                             examples:
                                 - assessments
                                 - characterization
@@ -3205,18 +3206,18 @@ node:
                                 - test
                                 - testing
                                 - tests
-                            name: laboratory_testing
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: life
                             examples:
                                 - life
                                 - lives
                                 - living
-                            name: life
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: malnutrition
                             examples:
                                 - acute malnutrition
                                 - gam
@@ -3234,20 +3235,20 @@ node:
                                 - wasting
                                 - weight for height
                                 - whz
-                            name: malnutrition
                             polarity: -1
                             semantic type: entity
                         - node:
+                            name: morbidity
                             examples:
                                 - DALY
                                 - disability
                                 - disability adjusted life year
                                 - high morbidity
                                 - morbidity
-                            name: morbidity
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: nutrients
                             examples:
                                 - adequate amounts
                                 - bioavailability
@@ -3293,10 +3294,10 @@ node:
                                 - vitamin
                                 - vitamin a
                                 - vitamins
-                            name: nutrients
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: nutrition
                             examples:
                                 - bioavailability
                                 - diet
@@ -3306,10 +3307,10 @@ node:
                                 - nutritional requirements
                                 - nutritional value
                                 - obesity
-                            name: nutrition
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: pathogen
                             examples:
                                 - bacteria
                                 - bacterium
@@ -3337,20 +3338,20 @@ node:
                                 - trypanosomes
                                 - virus
                                 - zoonotic pathogens
-                            name: pathogen
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: poor_childrens_health
                             examples:
                                 - child mortality
                                 - child stunting
                                 - infant mortality
                                 - lbw
                                 - stunting
-                            name: poor_childrens_health
                             polarity: -1
                             semantic type: entity
                         - node:
+                            name: protein_nutrient
                             examples:
                                 - crude protein
                                 - protein
@@ -3358,23 +3359,23 @@ node:
                                 - protein requirements
                                 - protein source
                                 - protein sources
-                            name: protein_nutrient
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: public_health
                             examples:
                                 - population health
                                 - public health
-                            name: public_health
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: public_safety
                             examples:
                                 - public safety
-                            name: public_safety
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: substance_abuse
                             examples:
                                 - alcohol abuse
                                 - cocaine
@@ -3383,28 +3384,28 @@ node:
                                 - narcotics
                                 - prescription drug abuse
                                 - substance abuse
-                            name: substance_abuse
                             polarity: -1
                             semantic type: event
                         - node:
                             name: treatment
                             children:
                                 - node:
+                                    name: intensive_care
                                     examples:
                                         - intensive care
-                                    name: intensive_care
                                     polarity: 1
                                     semantic type: event
                                 - node:
+                                    name: preventative_treatment
                                     examples:
                                         - preventative treatment
                                         - prophylactic
                                         - vaccine
                                         - well visit
-                                    name: preventative_treatment
                                     polarity: 1
                                     semantic type: event
                                 - node:
+                                    name: psychological_services
                                     examples:
                                         - anti-depressant
                                         - counseling
@@ -3412,10 +3413,10 @@ node:
                                         - psychological services
                                         - psychotherapy
                                         - therapy
-                                    name: psychological_services
                                     polarity: 1
                                     semantic type: event
                                 - node:
+                                    name: supplemental_feed
                                     examples:
                                         - additional feed
                                         - cumulative feed
@@ -3430,10 +3431,10 @@ node:
                                         - supplemental feed
                                         - supplementary feed
                                         - supplementary feeding
-                                    name: supplemental_feed
                                     polarity: 1
                                     semantic type: event
                         - node:
+                            name: vaccination
                             examples:
                                 - cell
                                 - covax
@@ -3452,10 +3453,10 @@ node:
                                 - vaccine
                                 - vat
                                 - virology
-                            name: vaccination
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: vector
                             definition: An agent that carries or transmits an infectious pathogen into another living organism.
                             examples:
                                 - excrement
@@ -3463,10 +3464,10 @@ node:
                                 - transmission
                                 - vector
                                 - water
-                            name: vector
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: weight_gain
                             examples:
                                 - body size
                                 - body weight
@@ -3481,36 +3482,36 @@ node:
                                 - weight gain
                                 - weight loss
                                 - weights
-                            name: weight_gain
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: welfare
                             examples:
                                 - living condition
                                 - welfare
-                            name: welfare
                             polarity: 1
                             semantic type: event
                 - node:
+                    name: homelessness
                     examples:
                         - homeless
-                    name: homelessness
                     polarity: -1
                     semantic type: entity
                 - node:
+                    name: human_rights
                     examples:
                         - freedom
                         - freedoms
                         - human rights
                         - liberties
                         - liberty
-                    name: human_rights
                     polarity: 1
                     semantic type: event
                 - node:
                     name: humanitarian_assistance
                     children:
                         - node:
+                            name: food_aid
                             examples:
                                 - CSB
                                 - food aid
@@ -3519,10 +3520,10 @@ node:
                                 - nutrition assistance
                                 - ration
                                 - school feeding
-                            name: food_aid
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: humanitarian_assistance
                             examples:
                                 - development assistance
                                 - emergency aid
@@ -3533,10 +3534,10 @@ node:
                                 - humanitarian interventions
                                 - international aid
                                 - urgent assistance
-                            name: humanitarian_assistance
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: non_food_items
                             examples:
                                 - NFI
                                 - buckets
@@ -3546,10 +3547,10 @@ node:
                                 - pots
                                 - soap
                                 - tarp
-                            name: non_food_items
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: voucher_or_cash
                             patterns:
                                 - \bcash\b
                                 - \bvouchers?\b
@@ -3558,48 +3559,48 @@ node:
                                 - food voucher
                                 - livelihood assistance
                                 - voucher or cash
-                            name: voucher_or_cash
                             polarity: 1
                             semantic type: event
                 - node:
+                    name: inequality
                     examples:
                         - discrepancy
                         - disparity
                         - imbalance
                         - inequality
                         - inequity
-                    name: inequality
                     polarity: -1
                     semantic type: event
                 - node:
                     name: information
                     children:
                         - node:
+                            name: information_technology
                             examples:
                                 - computers
                                 - digital technologies
                                 - information technology
-                            name: information_technology
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: intelligence_information
                             examples:
                                 - intelligence
                                 - intelligence analysis
                                 - intelligence information
-                            name: intelligence_information
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: internet
                             examples:
                                 - internet
                                 - mobile internet
                                 - web
                                 - world wide web
-                            name: internet
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: misinformation
                             examples:
                                 - disinformation
                                 - fake news
@@ -3608,10 +3609,10 @@ node:
                                 - misconception
                                 - misinformation
                                 - misreporting
-                            name: misinformation
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: rumor
                             examples:
                                 - allegation
                                 - myth
@@ -3619,16 +3620,15 @@ node:
                                 - rumor
                                 - rumour
                                 - speculation
-                            name: rumor
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: social_media
                             examples:
                                 - facebook
                                 - instagram
                                 - social media
                                 - twitter
-                            name: social_media
                             polarity: 1
                             semantic type: entity
                 - node:
@@ -3638,6 +3638,7 @@ node:
                             name: agriculture
                             children:
                                 - node:
+                                    name: farm_infrastructure
                                     examples:
                                         - barn
                                         - farm infrastructure
@@ -3645,18 +3646,18 @@ node:
                                         - livestock enclosure
                                         - nursery
                                         - post harvest infrastructure
-                                    name: farm_infrastructure
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: farmland
                                     examples:
                                         - agricultural land
                                         - arable land
                                         - farmland
-                                    name: farmland
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: slaughterhouse
                                     examples:
                                         - broiler producers
                                         - poultry producers
@@ -3667,10 +3668,10 @@ node:
                                         - slaughterhouse
                                         - slaughterhouses
                                         - slaughtering
-                                    name: slaughterhouse
                                     polarity: 1
                                     semantic type: entity
                         - node:
+                            name: communication
                             examples:
                                 - advertisement
                                 - article
@@ -3697,10 +3698,10 @@ node:
                                 - telecommunications
                                 - telephone
                                 - television
-                            name: communication
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: education_facilities
                             examples:
                                 - campus
                                 - child friendly learning spaces
@@ -3714,10 +3715,10 @@ node:
                                 - lecture hall
                                 - school
                                 - university
-                            name: education_facilities
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: electrical_infrastructure
                             examples:
                                 - electrical wiring
                                 - electricity
@@ -3726,19 +3727,19 @@ node:
                                 - power grid
                                 - power line
                                 - solar panel
-                            name: electrical_infrastructure
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: energy
                             examples:
                                 - electricity
                                 - energy
                                 - hydropower
                                 - wind power
-                            name: energy
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: energy_infrastructure
                             examples:
                                 - dam
                                 - energy
@@ -3748,19 +3749,19 @@ node:
                                 - power station
                                 - solar panel
                                 - wind turbine
-                            name: energy_infrastructure
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: flood_mitigation_infrastructure
                             examples:
                                 - dike
                                 - flood wall
                                 - levee
                                 - seawall
-                            name: flood_mitigation_infrastructure
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: housing
                             examples:
                                 - buildings
                                 - floors
@@ -3770,19 +3771,19 @@ node:
                                 - rooms
                                 - walls
                                 - windows
-                            name: housing
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: irrigation_infrastructure
                             patterns:
                                 - irrigation
                             examples:
                                 - canal
                                 - irrigation
-                            name: irrigation_infrastructure
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: medical_facilities
                             patterns:
                                 - \bclinics\b
                                 - \bhospitals?\b
@@ -3801,17 +3802,17 @@ node:
                                 - hospital
                                 - medical facilities
                                 - mobile clinics
-                            name: medical_facilities
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: mining_infrastructure
                             examples:
                                 - mine
                                 - mineshaft
-                            name: mining_infrastructure
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: refugee_camps
                             patterns:
                                 - \bcamps?\b
                                 - \brefugee\s+camps?\b
@@ -3820,10 +3821,10 @@ node:
                                 - refugee camp
                                 - refugee settlements
                                 - temporary housing
-                            name: refugee_camps
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: sanitation_infrastructure
                             patterns:
                                 - \blatrines?\b
                                 - \btoilets?\b
@@ -3832,53 +3833,53 @@ node:
                                 - latrines
                                 - sanitation
                                 - toilets
-                            name: sanitation_infrastructure
                             polarity: 1
                             semantic type: entity
                         - node:
                             name: transportation
                             children:
                                 - node:
+                                    name: bridge
                                     examples:
                                         - bridge
-                                    name: bridge
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: public_transportation
                                     examples:
                                         - public transport
                                         - public transportation
-                                    name: public_transportation
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: railroad_infrastructure
                                     examples:
                                         - rail
                                         - railroad
                                         - train
-                                    name: railroad_infrastructure
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: road_infrastructure
                                     examples:
                                         - highway
                                         - road
                                         - trucking
                                         - trucks
-                                    name: road_infrastructure
                                     polarity: 1
                                     semantic type: entity
                         - node:
+                            name: voting_infrastructure
                             examples:
                                 - ballot boxes
                                 - polling booths
                                 - voting locations
                                 - voting systems
                                 - voting tools
-                            name: voting_infrastructure
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: water_facilities
                             patterns:
                                 - \bborehole
                             examples:
@@ -3887,10 +3888,10 @@ node:
                                 - water point
                                 - water treatment center
                                 - wells
-                            name: water_facilities
                             polarity: 1
                             semantic type: entity
                 - node:
+                    name: innovation
                     examples:
                         - appropriate technologies
                         - different approaches
@@ -3909,10 +3910,10 @@ node:
                         - new tools
                         - new ways
                         - technologies
-                    name: innovation
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: intervention
                     examples:
                         - approaches
                         - appropriate actions
@@ -3943,16 +3944,16 @@ node:
                         - tools
                         - traditional methods
                         - wash interventions
-                    name: intervention
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: literacy
                     examples:
                         - literacy
-                    name: literacy
                     polarity: 1
                     semantic type: entity
                 - node:
+                    name: microbiology
                     examples:
                         - antimicrobials
                         - biotechnologies
@@ -3965,18 +3966,18 @@ node:
                         - organism
                         - probiotics
                         - termites
-                    name: microbiology
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: perception
                     examples:
                         - opinion
                         - perception
                         - perceptions
-                    name: perception
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: plan
                     examples:
                         - action
                         - action plan
@@ -4000,10 +4001,10 @@ node:
                         - transformation plan
                         - vision
                         - work plans
-                    name: plan
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: policy_making
                     examples:
                         - decision making
                         - policy
@@ -4011,36 +4012,36 @@ node:
                         - policy interventions
                         - policy makers
                         - policymaking
-                    name: policy_making
                     polarity: 1
                     semantic type: event
                 - node:
                     name: population_demographics
                     children:
                         - node:
+                            name: age
                             examples:
                                 - age
-                            name: age
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: clan
                             examples:
                                 - clan
                                 - family
-                            name: clan
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: ethnic_identity
                             examples:
                                 - ethnic identities
                                 - ethnic identity
                                 - identities
                                 - identity
                                 - identity groups
-                            name: ethnic_identity
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: gender
                             examples:
                                 - empowerment
                                 - equal opportunities
@@ -4057,54 +4058,54 @@ node:
                                 - sex
                                 - sexes
                                 - social determinants
-                            name: gender
                             polarity: 1
                             semantic type: entity
                         - node:
                             name: population_density
                             children:
                                 - node:
+                                    name: de-population
                                     examples:
                                         - de-population
                                         - depopulation
                                         - population decline
-                                    name: de-population
                                     polarity: -1
                                     semantic type: entity
                                 - node:
+                                    name: overcrowding
                                     examples:
                                         - overcrowding
-                                    name: overcrowding
                                     polarity: 1
                                     semantic type: entity
                                 - node:
+                                    name: population_growth
                                     examples:
                                         - population growth
-                                    name: population_growth
                                     polarity: 1
                                     semantic type: entity
                         - node:
+                            name: race_or_ethnicity
                             examples:
                                 - ethnicity
                                 - race
-                            name: race_or_ethnicity
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: religion
                             examples:
                                 - religion
-                            name: religion
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: tribe
                             examples:
                                 - ethnicity
                                 - tribal
                                 - tribe
-                            name: tribe
                             polarity: 1
                             semantic type: entity
                 - node:
+                    name: poverty
                     examples:
                         - poor communities
                         - poor consumers
@@ -4114,10 +4115,10 @@ node:
                         - poorer households
                         - poorest households
                         - poverty
-                    name: poverty
                     polarity: -1
                     semantic type: event
                 - node:
+                    name: regulations
                     examples:
                         - bans
                         - ceilings
@@ -4129,10 +4130,10 @@ node:
                         - restrictions
                         - restrictive measures
                         - sanctions
-                    name: regulations
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: ritual
                     examples:
                         - celebration
                         - ceremony
@@ -4142,10 +4143,10 @@ node:
                         - holiday
                         - observance
                         - ritual
-                    name: ritual
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: safety_net
                     examples:
                         - basic services
                         - civil registration
@@ -4158,63 +4159,63 @@ node:
                         - social services
                         - vouchers
                         - welfare
-                    name: safety_net
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: scavenging_system
                     examples:
                         - carcasses
                         - culling
                         - spoilage
-                    name: scavenging_system
                     polarity: 1
                     semantic type: event
                 - node:
                     name: security
                     children:
                         - node:
+                            name: community_security
                             examples:
                                 - community
                                 - mine clearance
                                 - policing
-                            name: community_security
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: economic_security
                             examples:
                                 - depreciation
                                 - economic security
                                 - economy
                                 - inflation
                                 - recession
-                            name: economic_security
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: environmental_security
                             examples:
                                 - environmental security
-                            name: environmental_security
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: national_security
                             examples:
                                 - diplomacy
                                 - military
                                 - national security
-                            name: national_security
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: surveillance_system
                             examples:
                                 - informant
                                 - monitor
                                 - spy
                                 - surveillance system
                                 - track
-                            name: surveillance_system
                             polarity: 1
                             semantic type: event
                 - node:
+                    name: social_structure_or_relationship
                     examples:
                         - cultural factors
                         - individual characteristics
@@ -4237,56 +4238,56 @@ node:
                         - social systems
                         - symbolic boundaries
                         - ties
-                    name: social_structure_or_relationship
                     polarity: 1
                     semantic type: event
                 - node:
                     name: storage
                     children:
                         - node:
+                            name: agricultural_storage
                             examples:
                                 - agricultural storage
                                 - granary
                                 - silo
                                 - warehouse
-                            name: agricultural_storage
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: general_storage_facilities
                             examples:
                                 - storage
                                 - storage facilities
                                 - warehouse
-                            name: general_storage_facilities
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: household_food_storage
                             examples:
                                 - household food storage
                                 - storage
-                            name: household_food_storage
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: stockpile_goods
                             examples:
                                 - stockpile
-                            name: stockpile_goods
                             polarity: 1
                             semantic type: entity
                 - node:
                     name: time
                     children:
                         - node:
+                            name: delay
                             examples:
                                 - delay
                                 - halt
                                 - postpone
                                 - stall
                                 - suspend
-                            name: delay
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: dry_season
                             examples:
                                 - arid
                                 - drought
@@ -4294,18 +4295,18 @@ node:
                                 - dry spells
                                 - drylands
                                 - summer
-                            name: dry_season
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: prolonged
                             examples:
                                 - ongoing
                                 - prolonged
                                 - protracted
-                            name: prolonged
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: season
                             examples:
                                 - crop calendar
                                 - crop season
@@ -4313,10 +4314,10 @@ node:
                                 - lean season
                                 - planting season
                                 - season
-                            name: season
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: wet_season
                             examples:
                                 - long rains
                                 - monsoon
@@ -4324,10 +4325,10 @@ node:
                                 - rainy seasons
                                 - wet
                                 - wet seasons
-                            name: wet_season
                             polarity: 1
                             semantic type: event
                 - node:
+                    name: trend
                     examples:
                         - bias
                         - demographics
@@ -4335,61 +4336,61 @@ node:
                         - pattern
                         - percentage change
                         - trend
-                    name: trend
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: turnout
                     examples:
                         - attendance
                         - turnout
-                    name: turnout
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: urbanization
                     examples:
                         - urbanization
-                    name: urbanization
                     polarity: 1
                     semantic type: event
         - node:
             name: process
             children:
                 - node:
+                    name: access
                     definition: The ability or right to approach, enter, exit, make use of, or communicate with something.
                     examples:
                         - access
-                    name: access
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: adapt
                     examples:
                         - adapt
                         - adaptability
                         - adaptation
                         - flexibility
-                    name: adapt
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: aid_or_assistance
                     examples:
                         - aid
                         - assist
                         - assistance
                         - help
                         - support
-                    name: aid_or_assistance
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: assessment
                     examples:
                         - analyze
                         - assess
                         - critique
                         - evaluate
-                    name: assessment
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: attempt
                     examples:
                         - attempt
                         - campaign
@@ -4397,10 +4398,10 @@ node:
                         - initiative
                         - program
                         - try
-                    name: attempt
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: breeding
                     examples:
                         - breed
                         - breeder
@@ -4438,16 +4439,16 @@ node:
                         - roosters
                         - semen
                         - stud
-                    name: breeding
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: censorship
                     examples:
                         - censorship
-                    name: censorship
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: clean
                     examples:
                         - clean
                         - clean up
@@ -4455,10 +4456,10 @@ node:
                         - sanitization
                         - sanitize
                         - wash
-                    name: clean
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: collaboration
                     examples:
                         - alliance
                         - allied
@@ -4469,10 +4470,10 @@ node:
                         - cooperate
                         - partner
                         - partnership
-                    name: collaboration
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: collecting
                     examples:
                         - collect
                         - collecting
@@ -4480,10 +4481,10 @@ node:
                         - compile
                         - gather
                         - hoard
-                    name: collecting
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: combining
                     examples:
                         - combine
                         - couple
@@ -4492,7 +4493,6 @@ node:
                         - link
                         - merge
                         - mix
-                    name: combining
                     polarity: 1
                     semantic type: event
                 - node:
@@ -4502,22 +4502,23 @@ node:
                             name: ask
                             children:
                                 - node:
+                                    name: poll
                                     examples:
                                         - canvass
                                         - poll
-                                    name: poll
                                     polarity: 1
                                     semantic type: event
                                 - node:
+                                    name: question
                                     examples:
                                         - ask
                                         - interrogate
                                         - interview
                                         - question
-                                    name: question
                                     polarity: 1
                                     semantic type: event
                         - node:
+                            name: campaign
                             examples:
                                 - advocate
                                 - campaign
@@ -4526,19 +4527,19 @@ node:
                                 - lobbying
                                 - persuade
                                 - promote
-                            name: campaign
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: commitment
                             examples:
                                 - commit
                                 - commitment
                                 - pledge
                                 - promise
-                            name: commitment
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: debate
                             examples:
                                 - argue
                                 - assert
@@ -4547,20 +4548,20 @@ node:
                                 - disagree
                                 - discuss
                                 - fight
-                            name: debate
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: deception
                             examples:
                                 - deceive
                                 - deception
                                 - deceptive
                                 - 'false'
                                 - misinform
-                            name: deception
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: description
                             examples:
                                 - describe
                                 - description
@@ -4569,10 +4570,10 @@ node:
                                 - outline
                                 - report
                                 - summarize
-                            name: description
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: endorsement
                             examples:
                                 - advocate
                                 - approve
@@ -4580,19 +4581,19 @@ node:
                                 - endorsement
                                 - espouse
                                 - support
-                            name: endorsement
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: highlighting
                             examples:
                                 - distinguish
                                 - emphasise
                                 - emphasize
                                 - highlight
-                            name: highlighting
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: informing
                             examples:
                                 - disclose
                                 - inform
@@ -4600,20 +4601,20 @@ node:
                                 - say
                                 - speak
                                 - tell
-                            name: informing
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: mediation
                             examples:
                                 - arbitrate
                                 - broker
                                 - mediate
                                 - mediation
                                 - referee
-                            name: mediation
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: meeting
                             examples:
                                 - assembly
                                 - conference
@@ -4628,18 +4629,18 @@ node:
                                 - seminar
                                 - summit
                                 - workshop
-                            name: meeting
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: negotiation
                             examples:
                                 - bargain
                                 - negotiate
                                 - negotiation
-                            name: negotiation
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: opposition
                             examples:
                                 - challenge
                                 - condemn
@@ -4658,30 +4659,30 @@ node:
                                 - reject
                                 - renounce
                                 - subvert
-                            name: opposition
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: suggestion
                             examples:
                                 - recommend
                                 - recommendation
                                 - suggest
                                 - suggestion
-                            name: suggestion
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: warning
                             examples:
                                 - caution
                                 - warn
                                 - warning
-                            name: warning
                             polarity: 1
                             semantic type: event
                 - node:
                     name: conflict
                     children:
                         - node:
+                            name: abduction
                             examples:
                                 - abducted
                                 - abduction
@@ -4691,27 +4692,27 @@ node:
                                 - kidnapped
                                 - kidnapping
                                 - ransomed
-                            name: abduction
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: abuse
                             examples:
                                 - abuse
                                 - harass
                                 - neglect
                                 - persecute
                                 - violate
-                            name: abuse
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: assassination
                             examples:
                                 - assassinate
                                 - assassination
-                            name: assassination
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: attack
                             examples:
                                 - airstrike
                                 - ambush
@@ -4737,28 +4738,28 @@ node:
                                 - shooting
                                 - shoots
                                 - strike
-                            name: attack
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: clan_conflict
                             examples:
                                 - clan conflict
                                 - clan differences
                                 - clan tensions
-                            name: clan_conflict
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: crackdown
                             examples:
                                 - crackdown
                                 - crush
                                 - overreact
                                 - repress
                                 - suppress
-                            name: crackdown
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: defeat
                             examples:
                                 - collapse
                                 - coup
@@ -4770,17 +4771,17 @@ node:
                                 - oust
                                 - overthrow
                                 - topple
-                            name: defeat
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: disarmament
                             examples:
                                 - ceasefire
                                 - disarmament
-                            name: disarmament
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: discriminate
                             examples:
                                 - discriminate
                                 - exclude
@@ -4788,20 +4789,20 @@ node:
                                 - profile
                                 - segregate
                                 - stigmatize
-                            name: discriminate
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: enlist
                             examples:
                                 - draft
                                 - enlist
                                 - marshal
                                 - muster
                                 - recruit
-                            name: enlist
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: exploit
                             definition: To make use of (sometimes unfairly) to one's own advantage.
                             examples:
                                 - cheat
@@ -4810,27 +4811,27 @@ node:
                                 - intimidate
                                 - lure
                                 - manipulate
-                            name: exploit
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: harass_or_persecute
                             examples:
                                 - harass
                                 - harassment
                                 - persecute
                                 - persecution
-                            name: harass_or_persecute
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: insurgency
                             examples:
                                 - insurgency
                                 - revolt
                                 - uprising
-                            name: insurgency
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: peacebuilding
                             examples:
                                 - conflict prevention
                                 - conflict resolution
@@ -4850,23 +4851,23 @@ node:
                                 - stabilization efforts
                                 - statebuilding
                                 - treaty
-                            name: peacebuilding
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: peacekeeping
                             examples:
                                 - peacekeepers
                                 - peacekeeping
-                            name: peacekeeping
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: police_brutality
                             examples:
                                 - police brutality
-                            name: police_brutality
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: protest_or_demonstration
                             examples:
                                 - assemble
                                 - boycott
@@ -4883,10 +4884,10 @@ node:
                                 - social unrest
                                 - strikes
                                 - turmoil
-                            name: protest_or_demonstration
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: resolution
                             examples:
                                 - accord
                                 - accords
@@ -4903,18 +4904,18 @@ node:
                                 - rapprochement
                                 - resolution
                                 - treaty
-                            name: resolution
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: retaliation
                             examples:
                                 - retaliation
                                 - retribution
                                 - revenge
-                            name: retaliation
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: terrorism
                             examples:
                                 - bomb threat
                                 - extremism
@@ -4927,25 +4928,25 @@ node:
                                 - terrorist acts
                                 - terrorist attack
                                 - violent extremism
-                            name: terrorism
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: threat
                             examples:
                                 - intimidate
                                 - threat
                                 - threaten
-                            name: threat
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: torture
                             examples:
                                 - excessive force
                                 - torture
-                            name: torture
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: tribal_conflict
                             examples:
                                 - ethnic conflict
                                 - ethnic conflicts
@@ -4958,10 +4959,10 @@ node:
                                 - historical conflict
                                 - intergroup conflict
                                 - tribal conflict
-                            name: tribal_conflict
                             polarity: -1
                             semantic type: event
                         - node:
+                            name: war
                             examples:
                                 - assault
                                 - attack
@@ -4975,83 +4976,83 @@ node:
                                 - war
                                 - warfare
                                 - warlord
-                            name: war
                             polarity: -1
                             semantic type: event
                 - node:
+                    name: construction
                     examples:
                         - build
                         - building
                         - construct
                         - construction
                         - establish
-                    name: construction
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: consumption
                     examples:
                         - consume
                         - consumption
                         - household consumption
                         - own consumption
                         - use
-                    name: consumption
                     polarity: -1
                     semantic type: event
                 - node:
+                    name: damage
                     examples:
                         - damage
                         - devastate
                         - ravage
-                    name: damage
                     polarity: -1
                     semantic type: event
                 - node:
+                    name: decision
                     examples:
                         - conclude
                         - decide
                         - decision
-                    name: decision
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: demand
                     examples:
                         - demand
                         - petition
                         - request
-                    name: demand
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: deployment
                     examples:
                         - deploy
                         - deployment
                         - dispatch
-                    name: deployment
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: depreciation
                     examples:
                         - depreciate
                         - devaluation
-                    name: depreciation
                     polarity: -1
                     semantic type: event
                 - node:
+                    name: destabilization
                     examples:
                         - destabilize
-                    name: destabilization
                     polarity: -1
                     semantic type: event
                 - node:
+                    name: destruction
                     examples:
                         - destroy
                         - destruction
                         - ruin
-                    name: destruction
                     polarity: -1
                     semantic type: event
                 - node:
+                    name: detection
                     examples:
                         - clinical signs
                         - detect
@@ -5059,10 +5060,10 @@ node:
                         - diagnose
                         - diagnostics
                         - signs
-                    name: detection
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: development
                     examples:
                         - broaden
                         - cultivate
@@ -5072,10 +5073,10 @@ node:
                         - extend
                         - grow
                         - growth
-                    name: development
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: disguise
                     examples:
                         - conceal
                         - disguise
@@ -5084,10 +5085,10 @@ node:
                         - mask
                         - shield
                         - stealth
-                    name: disguise
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: enhancement
                     examples:
                         - boost
                         - enhance
@@ -5098,34 +5099,34 @@ node:
                         - improvement
                         - supplement
                         - upgrade
-                    name: enhancement
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: evacuation
                     examples:
                         - evacuate
                         - evacuation
-                    name: evacuation
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: eviction
                     examples:
                         - dispossession
                         - eviction
-                    name: eviction
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: exploration
                     examples:
                         - discovery
                         - experimentation
                         - exploration
                         - findings
                         - investigation
-                    name: exploration
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: extraction
                     examples:
                         - compose
                         - derive
@@ -5133,83 +5134,83 @@ node:
                         - isolate
                         - source
                         - synthesize
-                    name: extraction
                     polarity: 1
                     semantic type: event
                 - node:
                     name: farming
                     children:
                         - node:
+                            name: harvesting
                             examples:
                                 - harvest
                                 - harvesting
                                 - reap
-                            name: harvesting
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: herding
                             examples:
                                 - grazing
                                 - herders
                                 - herding
                                 - herds
-                            name: herding
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: irrigation
                             definition: The process of applying controlled amounts of water to plants.
                             examples:
                                 - irrigate
                                 - irrigating
                                 - irrigation
-                            name: irrigation
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: planting
                             examples:
                                 - cultivate
                                 - planting
                                 - sow
-                            name: planting
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: tilling
                             examples:
                                 - tilling
-                            name: tilling
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: weeding
                             examples:
                                 - weeding
-                            name: weeding
                             polarity: 1
                             semantic type: event
                 - node:
+                    name: fishing
                     examples:
                         - aquaculture
                         - fish
                         - fisheries
                         - fishing
-                    name: fishing
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: flow
                     examples:
                         - diffuse
                         - diffusion
                         - flow
                         - trickle
-                    name: flow
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: foraging
                     examples:
                         - forage
-                    name: foraging
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: grouping
                     examples:
                         - band
                         - categorize
@@ -5217,10 +5218,10 @@ node:
                         - cluster
                         - group
                         - subdivide
-                    name: grouping
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: hatching
                     examples:
                         - abundance
                         - chick survival
@@ -5235,17 +5236,17 @@ node:
                         - survival
                         - survival rate
                         - survival rates
-                    name: hatching
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: hunting
                     examples:
                         - hunt
                         - poaching
-                    name: hunting
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: imprisonment_or_detention
                     examples:
                         - arrest
                         - captivity
@@ -5257,10 +5258,10 @@ node:
                         - imprison
                         - imprisonment
                         - incarcerate
-                    name: imprisonment_or_detention
                     polarity: -1
                     semantic type: event
                 - node:
+                    name: incubation
                     examples:
                         - artificial incubation
                         - brooder
@@ -5276,52 +5277,52 @@ node:
                         - poults
                         - rearing
                         - restocking
-                    name: incubation
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: infestation
                     patterns:
                         - \b[iI]nfest
                     examples:
                         - infest
                         - infestation
-                    name: infestation
                     polarity: -1
                     semantic type: event
                 - node:
+                    name: inflation
                     examples:
                         - inflation
-                    name: inflation
                     polarity: -1
                     semantic type: event
                 - node:
+                    name: inhabiting_or_occupancy
                     examples:
                         - inhabit
                         - live
                         - occupancy
                         - reside
                         - settle
-                    name: inhabiting_or_occupancy
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: intake
                     examples:
                         - consumption
                         - eating
                         - intake
-                    name: intake
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: investigate
                     examples:
                         - audit
                         - inquiry
                         - investigate
                         - investigation
-                    name: investigate
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: investment
                     examples:
                         - FDI
                         - foreign direct investment
@@ -5329,21 +5330,21 @@ node:
                         - invest
                         - investment
                         - spend
-                    name: investment
                     polarity: 1
                     semantic type: event
                 - node:
                     name: judicial
                     children:
                         - node:
+                            name: charge_or_prosecution
                             examples:
                                 - charge
                                 - indict
                                 - prosecute
-                            name: charge_or_prosecution
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: conviction_or_sentencing
                             examples:
                                 - convict
                                 - conviction
@@ -5354,13 +5355,13 @@ node:
                                 - punish
                                 - sentence
                                 - sentencing
-                            name: conviction_or_sentencing
                             polarity: 1
                             semantic type: event
                 - node:
                     name: legislation
                     children:
                         - node:
+                            name: regulation
                             patterns:
                                 - \b(regulations?|laws?)\b
                             examples:
@@ -5371,27 +5372,27 @@ node:
                                 - regulatory framework
                                 - repeal
                                 - restrict
-                            name: regulation
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: subsidization
                             examples:
                                 - subsidize
                                 - subsidy
-                            name: subsidization
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: taxation
                             examples:
                                 - duty
                                 - levy
                                 - tariff
                                 - tax
                                 - taxation
-                            name: taxation
                             polarity: 1
                             semantic type: event
                 - node:
+                    name: management
                     examples:
                         - NRM
                         - administrate
@@ -5399,73 +5400,73 @@ node:
                         - manage
                         - management
                         - oversee
-                    name: management
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: manipulation
                     examples:
                         - control
                         - exploit
                         - influence
                         - manipulate
-                    name: manipulation
                     polarity: 1
                     semantic type: event
                 - node:
                     name: medical
                     children:
                         - node:
+                            name: contact_tracing
                             patterns:
                                 - (contact tracing)
                             examples:
                                 - contact tracing
-                            name: contact_tracing
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: lockdown
                             examples:
                                 - lockdown
-                            name: lockdown
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: quarantine
                             patterns:
                                 - (quarantin|shelter[- ]in[- ]place)
                                 - \b(restrict\s+movement)
                             examples:
                                 - isolation
                                 - quarantine
-                            name: quarantine
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: sanitization
                             examples:
                                 - cleaning
                                 - disinfect
                                 - disinfection
                                 - sanitization
                                 - sanitize
-                            name: sanitization
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: social_distancing
                             patterns:
                                 - (social distanc)
                             examples:
                                 - curfew
                                 - social distancing
-                            name: social_distancing
                             polarity: 1
                             semantic type: event
                 - node:
+                    name: mining
                     examples:
                         - drilling
                         - fracking
                         - mining
-                    name: mining
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: mitigation
                     definition: make less severe, serious, or painful; lessen the gravity
                     examples:
                         - alleviate
@@ -5478,17 +5479,17 @@ node:
                         - mitigation
                         - neutralize
                         - overcome
-                    name: mitigation
                     polarity: -1
                     semantic type: event
                 - node:
+                    name: modification
                     examples:
                         - change
                         - modify
-                    name: modification
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: motivation
                     examples:
                         - drive
                         - drove
@@ -5500,17 +5501,17 @@ node:
                         - spark
                         - spurred
                         - trigger
-                    name: motivation
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: nomination
                     examples:
                         - nominate
                         - nomination
-                    name: nomination
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: observation
                     examples:
                         - detect
                         - observe
@@ -5518,38 +5519,38 @@ node:
                         - sense
                         - survey
                         - watch
-                    name: observation
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: outbreak
                     examples:
                         - outbreak
                         - outbreaks
                         - plague
                         - recent outbreaks
-                    name: outbreak
                     polarity: -1
                     semantic type: event
                 - node:
+                    name: planning
                     examples:
                         - design
                         - plan
                         - strategy
-                    name: planning
                     polarity: 1
                     semantic type: event
                 - node:
                     name: population
                     children:
                         - node:
+                            name: birth
                             patterns:
                                 - birth
                             examples:
                                 - birth
-                            name: birth
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: death
                             examples:
                                 - burial
                                 - casualties
@@ -5567,40 +5568,40 @@ node:
                                 - murder
                                 - new deaths
                                 - total deaths
-                            name: death
                             polarity: 1
                             semantic type: event
                         - node:
                             name: migrate
                             children:
                                 - node:
+                                    name: emigrate
                                     examples:
                                         - deport
                                         - emigrate
                                         - emigration
                                         - expel
-                                    name: emigrate
                                     polarity: 1
                                     semantic type: event
                                 - node:
+                                    name: immigrate
                                     examples:
                                         - asylum
                                         - immigrate
                                         - immigration
                                         - invade
-                                    name: immigrate
                                     polarity: 1
                                     semantic type: event
                                 - node:
+                                    name: migrate
                                     examples:
                                         - flee
                                         - migrate
                                         - migration
                                         - relocate
-                                    name: migrate
                                     polarity: 1
                                     semantic type: event
                 - node:
+                    name: prediction
                     examples:
                         - anticipate
                         - forecast
@@ -5608,28 +5609,28 @@ node:
                         - prediction
                         - project
                         - projection
-                    name: prediction
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: preparation
                     examples:
                         - organize
                         - plan
                         - prepare
-                    name: preparation
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: prevention
                     definition: keep something from happening or arising
                     examples:
                         - limit
                         - prevent
                         - suppress
                         - thwart
-                    name: prevention
                     polarity: -1
                     semantic type: event
                 - node:
+                    name: processing
                     examples:
                         - cleaning
                         - grading
@@ -5639,29 +5640,29 @@ node:
                         - shipping
                         - sorting
                         - treatment
-                    name: processing
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: production
                     patterns:
                         - \b([pP]roduction|[yY]ields?)\b
                     examples:
                         - create
                         - produce
                         - production
-                    name: production
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: prohibition
                     examples:
                         - ban
                         - criminalize
                         - outlaw
                         - prohibit
-                    name: prohibition
                     polarity: -1
                     semantic type: event
                 - node:
+                    name: provision
                     examples:
                         - administer
                         - deliver
@@ -5669,10 +5670,10 @@ node:
                         - give
                         - provide
                         - supply
-                    name: provision
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: publication
                     examples:
                         - broadcast
                         - print
@@ -5681,32 +5682,32 @@ node:
                         - release
                         - reprint
                         - write
-                    name: publication
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: radicalization
                     examples:
                         - radicalization
-                    name: radicalization
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: reaction_or_response
                     examples:
                         - react
                         - reaction
                         - respond
                         - response
-                    name: reaction_or_response
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: relief
                     examples:
                         - forgiveness
                         - relief
-                    name: relief
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: remediation
                     definition: provide a remedy for; redress or make right; restore by reversing or stopping environmental damage
                     examples:
                         - reconcile
@@ -5714,28 +5715,28 @@ node:
                         - resolve
                         - settle
                         - solve
-                    name: remediation
                     polarity: -1
                     semantic type: event
                 - node:
+                    name: repair
                     examples:
                         - reconstruct
                         - repair
                         - restore
-                    name: repair
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: reproduction
                     examples:
                         - hens
                         - laying hens
                         - reproduce
                         - reproduction
                         - rooster
-                    name: reproduction
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: research
                     definition: The collection, organization, and analysis of information to increase understanding of a topic or issue.
                     examples:
                         - experiment
@@ -5745,10 +5746,10 @@ node:
                         - scientific
                         - study
                         - survey
-                    name: research
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: securing
                     examples:
                         - conserve
                         - defend
@@ -5758,32 +5759,32 @@ node:
                         - safeguard
                         - secure
                         - ward
-                    name: securing
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: selection
                     examples:
                         - choose
                         - select
                         - selection
-                    name: selection
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: sharing
                     examples:
                         - share
                         - sharing
-                    name: sharing
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: stabilization
                     examples:
                         - stabilization
                         - stabilize
-                    name: stabilization
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: stalling
                     examples:
                         - delay
                         - hamper
@@ -5791,108 +5792,108 @@ node:
                         - shorten
                         - stall
                         - temper
-                    name: stalling
                     polarity: -1
                     semantic type: event
                 - node:
+                    name: start
                     examples:
                         - begin
                         - commence
                         - initiate
                         - start
-                    name: start
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: stay_or_remain
                     examples:
                         - continue
                         - exist
                         - remain
                         - stay
-                    name: stay_or_remain
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: strengthening
                     examples:
                         - prop up
                         - shore up
                         - strengthen
-                    name: strengthening
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: surveilance
                     examples:
                         - monitor
                         - surveil
-                    name: surveilance
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: tabulation
                     examples:
                         - count
                         - enumerate
                         - tabulate
-                    name: tabulation
                     polarity: 1
                     semantic type: event
                 - node:
                     name: trade
                     children:
                         - node:
+                            name: export
                             patterns:
                                 - \bexports?\b
                             examples:
                                 - export
-                            name: export
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: import
                             patterns:
                                 - \bimports?\b
                             examples:
                                 - import
-                            name: import
                             polarity: 1
                             semantic type: event
                 - node:
                     name: training
                     children:
                         - node:
+                            name: agriculture_training
                             examples:
                                 - agriculture training
                                 - pest control
                                 - post harvest
                                 - production practices
                                 - weed control
-                            name: agriculture_training
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: financial_training
                             examples:
                                 - financial training
-                            name: financial_training
                             polarity: 1
                             semantic type: event
                         - node:
                             name: humanitarian_training
                             children:
                                 - node:
+                                    name: emergency_preparedness_training
                                     patterns:
                                         - (SPHERE)
                                     examples:
                                         - SPHERE
                                         - emergency preparedness training
                                         - humanitarian certifications
-                                    name: emergency_preparedness_training
                                     polarity: 1
                                     semantic type: event
                         - node:
+                            name: medical_training
                             examples:
                                 - medical training
-                            name: medical_training
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: training
                             examples:
                                 - abilities
                                 - advice
@@ -5947,10 +5948,10 @@ node:
                                 - training programs
                                 - training session
                                 - vocational training
-                            name: training
                             polarity: 1
                             semantic type: event
                 - node:
+                    name: transaction
                     examples:
                         - buy
                         - food transaction
@@ -5962,18 +5963,18 @@ node:
                         - sell
                         - selling
                         - transaction
-                    name: transaction
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: transformation
                     examples:
                         - modernize
                         - reform
                         - transform
-                    name: transformation
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: transmission
                     examples:
                         - airborne
                         - community spread
@@ -5981,72 +5982,72 @@ node:
                         - infectious
                         - spread
                         - transmission
-                    name: transmission
                     polarity: -1
                     semantic type: event
                 - node:
                     name: transportation
                     children:
                         - node:
+                            name: commercial_transportation
                             examples:
                                 - air travel
                                 - commercial transportation
                                 - public transport
-                            name: commercial_transportation
                             polarity: 1
                             semantic type: event
                         - node:
+                            name: personal_transportation
                             examples:
                                 - commute
                                 - personal transportation
                                 - taxi
-                            name: personal_transportation
                             polarity: 1
                             semantic type: event
                 - node:
+                    name: travel
                     examples:
                         - journey
                         - travel
                         - trip
                         - visit
-                    name: travel
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: voting
                     examples:
                         - cast ballot
                         - elect
                         - vote
-                    name: voting
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: weakening
                     examples:
                         - undermine
                         - weaken
-                    name: weakening
                     polarity: -1
                     semantic type: event
         - node:
             name: property
             children:
                 - node:
+                    name: accountability
                     examples:
                         - accountability
                         - responsibility
-                    name: accountability
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: affordability
                     examples:
                         - affordable
                         - cost-effective
                         - economical
                         - reasonably priced
-                    name: affordability
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: aftermath
                     examples:
                         - aftermath
                         - fallout
@@ -6055,23 +6056,23 @@ node:
                         - result
                         - trauma
                         - wake
-                    name: aftermath
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: allegiance
                     examples:
                         - allegiance
                         - loyalty
-                    name: allegiance
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: availability
                     examples:
                         - availability
-                    name: availability
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: chronic
                     examples:
                         - chronic
                         - endemic
@@ -6086,19 +6087,19 @@ node:
                         - recurrent
                         - systemic
                         - widespread
-                    name: chronic
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: civic
                     definition: relating to ordinary citizens and their concerns
                     examples:
                         - citizen
                         - civic
                         - civil
-                    name: civic
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: common_understanding
                     examples:
                         - awareness
                         - clarity
@@ -6106,17 +6107,17 @@ node:
                         - insight
                         - mutual understanding
                         - public awareness
-                    name: common_understanding
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: condition
                     examples:
                         - condition
                         - conditions
-                    name: condition
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: coping_capacities
                     examples:
                         - absorptive capacity
                         - adaptive capacity
@@ -6132,23 +6133,23 @@ node:
                         - response capacities
                         - response capacity
                         - vulnerability
-                    name: coping_capacities
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: diversity
                     examples:
                         - diversity
-                    name: diversity
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: domestic
                     examples:
                         - domestic
                         - internal
-                    name: domestic
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: drug_resistance
                     examples:
                         - antibiotic resistance
                         - antimicrobial resistance
@@ -6162,31 +6163,31 @@ node:
                         - resistance
                         - resistant pathogens
                         - transporters
-                    name: drug_resistance
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: efficiency
                     examples:
                         - efficiency
-                    name: efficiency
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: exotic_breeds
                     examples:
                         - exotic breeds
-                    name: exotic_breeds
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: fairness
                     examples:
                         - equality
                         - equity
                         - fairness
                         - integrity
-                    name: fairness
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: foreign
                     examples:
                         - bilateral
                         - external aid
@@ -6194,51 +6195,51 @@ node:
                         - foreign aid
                         - multilateral
                         - overseas
-                    name: foreign
                     polarity: 1
                     semantic type: property
                 - node:
                     name: geographic_resolution
                     children:
                         - node:
+                            name: global
                             examples:
                                 - global
                                 - world
-                            name: global
                             polarity: 1
                             semantic type: property
                         - node:
+                            name: international
                             examples:
                                 - international
-                            name: international
                             polarity: 1
                             semantic type: property
                         - node:
+                            name: local
                             examples:
                                 - city
                                 - local
                                 - town
-                            name: local
                             polarity: 1
                             semantic type: property
                         - node:
+                            name: national
                             examples:
                                 - nation
                                 - national
                                 - state
-                            name: national
                             polarity: 1
                             semantic type: entity
                         - node:
+                            name: sub-national
                             examples:
                                 - kebele
                                 - provincial
                                 - regional
                                 - woreda
-                            name: sub-national
                             polarity: 1
                             semantic type: property
                 - node:
+                    name: hybrid_breeds
                     examples:
                         - commercial breeds
                         - crossbred
@@ -6255,61 +6256,61 @@ node:
                         - improved stock
                         - kuroiler
                         - new breeds
-                    name: hybrid_breeds
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: hydroponic
                     examples:
                         - hydroponic
-                    name: hydroponic
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: insecurity
                     examples:
                         - dangerous
                         - insecure
                         - insecurity
                         - unsafe
-                    name: insecurity
                     polarity: -1
                     semantic type: property
                 - node:
+                    name: instability
                     examples:
                         - instability
-                    name: instability
                     polarity: -1
                     semantic type: property
                 - node:
+                    name: legality
                     examples:
                         - constitutional
                         - constitutionality
                         - legal
                         - legality
-                    name: legality
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: nonutilization
                     examples:
                         - nonutilization
-                    name: nonutilization
                     polarity: -1
                     semantic type: property
                 - node:
+                    name: peaceful
                     examples:
                         - peaceful
-                    name: peaceful
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: preference
                     examples:
                         - choice
                         - preference
                         - preferences
                         - taste
-                    name: preference
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: preparedness
                     examples:
                         - action
                         - contingency planning
@@ -6329,10 +6330,10 @@ node:
                         - strategic plan
                         - task force
                         - vulnerability assessment
-                    name: preparedness
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: price_or_cost
                     patterns:
                         - \b([Cc]osts?|[Pp]rices?)\b
                     examples:
@@ -6351,60 +6352,60 @@ node:
                         - price
                         - recurrent costs
                         - social costs
-                    name: price_or_cost
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: private
                     examples:
                         - private
-                    name: private
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: productivity
                     examples:
                         - egg productivity
                         - performance
                         - poultry meat productivity
                         - productivity
-                    name: productivity
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: public
                     examples:
                         - public
-                    name: public
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: quality
                     examples:
                         - feed quality
                         - quality
-                    name: quality
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: resilience
                     examples:
                         - resilience
                         - resiliency
                         - robustness
-                    name: resilience
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: right_to_use
                     examples:
                         - land rights
                         - land tenure
                         - right to use
-                    name: right_to_use
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: risk
                     examples:
                         - risk
-                    name: risk
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: seasonality
                     examples:
                         - cycles
                         - delayed
@@ -6424,31 +6425,31 @@ node:
                         - significant changes
                         - timing
                         - variations
-                    name: seasonality
                     polarity: 1
                     semantic type: event
                 - node:
+                    name: security
                     examples:
                         - safety
                         - security
-                    name: security
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: social
                     examples:
                         - social
-                    name: social
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: stability
                     definition: Being unlikely to move or change.
                     examples:
                         - order
                         - stability
-                    name: stability
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: support
                     examples:
                         - affinity
                         - camaraderie
@@ -6456,10 +6457,10 @@ node:
                         - goodwill
                         - solidarity
                         - support
-                    name: support
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: surplus
                     examples:
                         - agricultural surplus
                         - egg surplus
@@ -6467,31 +6468,31 @@ node:
                         - marketable surplus
                         - meat surplus
                         - surplus
-                    name: surplus
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: sustainable
                     examples:
                         - sustainability
                         - sustainable
-                    name: sustainable
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: temporary
                     examples:
                         - makeshift
                         - temporary
-                    name: temporary
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: transparency
                     examples:
                         - openness
                         - transparency
-                    name: transparency
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: unavailability
                     examples:
                         - lack
                         - paucity
@@ -6500,24 +6501,24 @@ node:
                         - shortage
                         - sparse
                         - unavailability
-                    name: unavailability
                     polarity: -1
                     semantic type: property
                 - node:
+                    name: uncertainty
                     definition: An epistemic situation involving imperfect or unknown information.
                     examples:
                         - uncertainty
                         - volatility
-                    name: uncertainty
                     polarity: -1
                     semantic type: property
                 - node:
+                    name: utilization
                     examples:
                         - utilization
-                    name: utilization
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: variability
                     examples:
                         - precarious
                         - tumult
@@ -6526,23 +6527,22 @@ node:
                         - variable
                         - volatile
                         - volatility
-                    name: variability
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: violent
                     examples:
                         - violent
-                    name: violent
                     polarity: 1
                     semantic type: property
                 - node:
+                    name: vulnerability
                     examples:
                         - fragile
                         - fragility
                         - tenuous
                         - vulnerability
                         - vulnerable
-                    name: vulnerability
                     polarity: 1
                     semantic type: property
 

--- a/CompositionalOntology_metadata.yml
+++ b/CompositionalOntology_metadata.yml
@@ -1,6447 +1,6548 @@
-- wm:
-  - concept:
-    - agriculture:
-      - OntologyNode:
-        examples:
-        - additives
-        - amounts
-        - balanced feed
-        - batches
-        - broiler feed
-        - complementary foods
-        - conversion
-        - diet
-        - drug
-        - enzyme
-        - feed additives
-        - feed conversion
-        - feed formulation
-        - feed formulations
-        - feed ingredient
-        - feed ingredients
-        - feed material
-        - feed materials
-        - feed prices
-        - feed requirements
-        - feed supplements
-        - feeders
-        - feeding system
-        - feedlot
-        - feeds
-        - feedstuffs
-        - formula
-        - formulation
-        - herbs
-        - ingredient
-        - labelling
-        - labels
-        - milling
-        - mixed feed
-        - parent stocks
-        - protein source
-        - rations
-        - replacement
-        - supplementation
-        name: animal_feed
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - agricultural science
-        - agriculture organization
-        - animal breeding
-        - animal health
-        - animal production
-        - animal resources
-        - animal science
-        - field
-        - fishery
-        - genetic improvement
-        - genetics
-        - holding
-        - livestock
-        - livestock development
-        - livestock ownership
-        - livestock research
-        - livestock revolution
-        - livestock science
-        - poultry science
-        - research
-        - veterinary medicine
-        - veterinary microbiology
-        - veterinary science
-        name: animal_science
-        polarity: 1
-        semantic type: event
-      - crop:
-        - OntologyNode:
-          definition: A grass cultivated for the edible parts of its grain.
-          examples:
-          - barley
-          - cereals
-          - maize
-          - sorghum
-          - tef
-          - wheat
-          name: cereals
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - crop land
-          name: crop_land
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - cereals
-          - crop
-          - crop production
-          - crop season
-          - croplands
-          - main cropping
-          - main crops
-          - major crops
-          - paddy
-          - paddy rice
-          - planting
-          - rice crops
-          - root
-          - season
-          - sowing
-          - staple
-          - staple crops
-          - tree crops
-          name: crops
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - fodder
-          name: fodder
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - maize
-          - maize grain
-          - maize meal
-          - white maize
-          - yellow maize
-          name: maize
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - major crops
-          name: major_crops
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - other crops
-          name: other_crops
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - beans
-          - lentils
-          - peas
-          - pulses
-          name: pulses
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - red sorghum
-          - sorghum
-          - sorghum crops
-          - white sorghum
-          name: sorghum
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - standing crops
-          name: standing_crops
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - staple crops
-          name: staple_crops
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - tree crops
-          name: tree_crops
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - cassava
-          - potato
-          - sweet potato
-          - tubers
-          name: tubers
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          definition: vegetable crops and food
-          examples:
-          - beets
-          - cabbage
-          - carrots
-          - lettuce
-          - tomato
-          - vegetables
-          name: vegetables
-          polarity: 1
-          semantic type: entity
-      - OntologyNode:
-        examples:
-        - cheese
-        - contract farming
-        - cows
-        - dairy
-        - dairy animals
-        - dairy cows
-        - dairy farmers
-        - dairy farms
-        - dairy industry
-        - dairy producers
-        - dairy sector
-        - dairy systems
-        - goat
-        - larger producers
-        - milk
-        - milk production
-        - processors
-        - producing
-        - specialized dairy
-        name: dairy
-        polarity: 1
-        semantic type: event
-      - disease:
-        - OntologyNode:
-          examples:
-          - blight
-          - crop disease
-          name: crop_disease
-          polarity: -1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - livestock disease
-          name: livestock_disease
-          polarity: -1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - chicken disease
-          - colibacillosis
-          - coryza
-          - poultry disease
-          name: poultry_disease
-          polarity: 1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - veterinarian
-          - veterinarians
-          - veterinary authorities
-          - veterinary care
-          - veterinary clinics
-          - veterinary department
-          - veterinary journal
-          - veterinary medicine
-          - veterinary science
-          - veterinary service
-          - veterinary services
-          name: veterinary_care
-          polarity: 1
-          semantic type: event
-      - OntologyNode:
-        definition: Domesticated animals raised for their labor or to produce commodities
-          such as milk, meat, eggs, fur, leather, or wool.
-        examples:
-        - beef
-        - bull
-        - calf
-        - calves
-        - camel
-        - cattle
-        - cow
-        - dairy cattle
-        - dairy products
-        - donkey
-        - goats
-        - herds
-        - horse
-        - livestock
-        - milk
-        - ox
-        - oxen
-        - pigs
-        - sheep
-        name: livestock_nonpoultry
-        polarity: 1
-        semantic type: event
-      - pest:
-        - OntologyNode:
-          examples:
-          - few swarms
-          - fleas
-          - flies
-          - fly
-          - fomites
-          - infestations
-          - insect
-          - insects
-          - larvae
-          - lice
-          - microbes
-          - mites
-          - mosquito
-          - mosquitoes
-          - new swarms
-          - parasites
-          - pests
-          - small groups
-          - small swarms
-          - swarms
-          - ticks
-          - worms
-          name: animal_pests
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - army worm
-          name: army_worm
-          polarity: -1
-          semantic type: event
-        - locust:
-          - OntologyNode:
-            examples:
-            - desert locust
-            name: desert_locust
-            polarity: 1
-            semantic type: entity
-          - gregarious:
-            - OntologyNode:
-              examples:
-              - bands of hoppers
-              - immature
-              - locust hopper groups
-              name: hopper_band
-              pattern:
-              - (hopper\s+band)|(bands?\s+of\s+hoppers)
-              polarity: -1
-              semantic type: event
-            - OntologyNode:
-              examples:
-              - adult
-              - locust infestation
-              - locust swarm
-              - mature maturation
-              - swarm
-              name: locust_swarm
-              pattern:
-              - (locust\s+swarm)|(swarms?\s+of\s+locust)
-              - \bDL\b
-              - locust
-              polarity: -1
-              semantic type: event
-          - OntologyNode:
-            examples:
-            - locust eggs
-            name: locust_eggs
-            polarity: -1
-            semantic type: event
-          - solitary:
-            - OntologyNode:
-              examples:
-              - hopper
-              - immature
-              - instar
-              - solitarious hopper
-              - solitary
-              name: solitary_hopper
-              polarity: -1
-              semantic type: event
-            - OntologyNode:
-              examples:
-              - mature
-              - solitarious adult locust
-              - solitary locust
-              name: solitary_locust
-              polarity: -1
-              semantic type: event
-      - poultry:
-        - OntologyNode:
-          examples:
-          - ancestors
-          - backyard
-          - backyard farms
-          - backyard flocks
-          - backyard producers
-          - backyard system
-          - backyard systems
-          - backyards
-          - commercial systems
-          - coops
-          - follower farmers
-          - gardens
-          - homesteads
-          - peasant
-          - rearing activities
-          - rural producers
-          - small flocks
-          - smallholder
-          - traditional backyard
-          - traditional chickens
-          - traditional methods
-          - traditional practices
-          - traditional system
-          - traditional systems
-          - yard
-          name: backyard_poultry_farming
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - healthy birds
-          - live birds
-          - new birds
-          - vaccinated birds
-          name: bird_condition_healthy
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - affected birds
-          - avian pathology
-          - bats
-          - carrier
-          - carriers
-          - culled birds
-          - dead birds
-          - dead chickens
-          - diseased birds
-          - healthy birds
-          - hosts
-          - infected birds
-          - infected farms
-          - infected msc
-          - live birds
-          - new birds
-          - old chicks
-          - sick animals
-          - sick birds
-          - sick chickens
-          name: bird_condition_sick
-          polarity: -1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - broiler
-          - broiler chickens
-          - broilers
-          - commercial breeds
-          - commercial chickens
-          - commercial lines
-          - kuroiler
-          - meat chickens
-          name: broiler_chickens
-          polarity: 1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - cock
-          - cockerel
-          - cockerels
-          - cocks
-          - male chicken
-          - rooster
-          - stud
-          name: cockerel
-          polarity: 1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - DOC
-          - babies
-          - baby chicks
-          - broiler chicks
-          - chick
-          - chick mortality
-          - chicks
-          - day old chicks
-          - embryo
-          - hatcheries
-          - nests
-          - offspring
-          name: day_old_chicks
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - clutch
-          - egg clutch
-          - egg number
-          - egg offtake
-          - egg size
-          - egg weight
-          - eggs
-          - embryo
-          - hatchability
-          - high egg
-          - shell
-          - shell thickness
-          - total egg
-          - yolk
-          name: egg
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - backyard flocks
-          - base situation
-          - bird flocks
-          - bird market
-          - commercial flocks
-          - flock
-          - flock size
-          - flock sizes
-          - flock structure
-          - flocks
-          - larger flocks
-          - plumage colour
-          - restocking
-          - small flock
-          - small flocks
-          - whole flock
-          name: flock_size
-          polarity: 1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - domestic ducks
-          - domestic fowl
-          - duck
-          - duck raising
-          - ducklings
-          - ducks
-          - fowl
-          - fowl pox
-          - fowls
-          - geese
-          - goose
-          - muscovy ducks
-          - ostriches
-          - other species
-          - pheasants
-          - pigeon
-          - quail
-          - quails
-          - swan
-          - waterfowl
-          - wild bird
-          name: fowl
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - backyard chickens
-          - backyard flocks
-          - breeds
-          - crosses
-          - domestic chickens
-          - improved indigenous
-          - indigenous animals
-          - indigenous breeds
-          - indigenous chickens
-          - indigenous hens
-          - indigenous populations
-          - local breeds
-          - mixed systems
-          - native breeds
-          - native chickens
-          - races
-          - scavenging chickens
-          - traditional breeds
-          - traditional chickens
-          name: indigenous_breeds
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - brooder
-          - brooders
-          - broody hen
-          - broody hens
-          - commercial layers
-          - female chicken
-          - hatchery
-          - hen
-          - hens
-          - indigenous hens
-          - laying hens
-          - mother
-          - mother hen
-          - mothers
-          - rearers
-          - spent hens
-          name: laying_hens
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - chicken
-          - egg
-          - poultry
-          name: poultry
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - commercial farms
-          - commercial producers
-          - egg traders
-          - feed industry
-          - feed sector
-          - hatcheries
-          - livestock sector
-          - poultry farmers
-          - poultry feed
-          - poultry industry
-          - poultry meat
-          - poultry producers
-          - poultry production
-          - poultry products
-          - poultry sci
-          - poultry science
-          - poultry sector
-          - slaughterhouses
-          - veterinary department
-          name: poultry_sector
-          polarity: 1
-          semantic type: event
-    - OntologyNode:
-      examples:
-      - civil liberties
-      name: civil_liberties
-      polarity: 1
-      semantic type: entity
-    - OntologyNode:
-      examples:
-      - civil society
-      name: civil_society
-      polarity: 1
-      semantic type: entity
-    - crisis_or_disaster:
-      - conflict:
-        - OntologyNode:
-          examples:
-          - acts
-          - armed
-          - armed conflict
-          - armed conflicts
-          - civil conflicts
-          - civil wars
-          - combatants
-          - conflict
-          - conflict resolution
-          - crime
-          - disorder
-          - drug
-          - fighting
-          - foreign fighters
-          - havoc
-          - hostilities
-          - intra
-          - jihadism
-          - killing
-          - proliferation
-          - terrorists
-          - threats
-          - violent conflict
-          - wars
-          name: armed_conflict
-          polarity: 1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - abduction
-          - assault
-          - blackmail
-          - bribery
-          - burglary
-          - corruption
-          - crime
-          - crimes
-          - criminal
-          - cybercrimes
-          - domestic violence
-          - embezzlement
-          - exploitation
-          - extortion
-          - harassment
-          - homicide
-          - illegal
-          - illegal activities
-          - illicit activities
-          - kidnap
-          - kidnapping
-          - laundering
-          - lawlessness
-          - looted
-          - looting
-          - murdered
-          - racketeering
-          - rape
-          - riots
-          - robbery
-          - sexual abuse
-          - sexual exploitation
-          - smuggling
-          - steal
-          - stealing
-          - stolen
-          - terrorism
-          - theft
-          - torture
-          - trafficing
-          - trafficking
-          - vandalism
-          - violations
-          - violent crime
-          name: crime
-          polarity: -1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - alienation
-          - anger
-          - backlash
-          - contention
-          - controversy
-          - criticism
-          - discontent
-          - dissatisfaction
-          - dissent
-          - distrust
-          - friction
-          - frustration
-          - frustrations
-          - grievance
-          - protest
-          - rejection
-          - resentment
-          - sentiments
-          - unrest
-          name: discontent
-          polarity: -1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - armed clash
-          - armed groups
-          - armed mobilization
-          - army mobilization
-          - clash
-          - clashes
-          - conflict
-          - feud
-          - fighting
-          - genocide
-          - hostility
-          - infighting
-          - insurgency
-          - oppression
-          - oppressive regime
-          - raid
-          - regional turmoil
-          - sabotage
-          - skirmish
-          - tyranny
-          - vandalized
-          - violence
-          - violence in the region
-          - war
-          name: hostility
-          polarity: -1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - adversity
-          - burden
-          - challenge
-          - distress
-          - faction
-          - feud
-          - frustration
-          - hardship
-          - mistrust
-          - polarization
-          - political instability
-          - political tension
-          - political tensions
-          - resentment
-          - rivalry
-          - stalemate
-          - stress
-          - threatening
-          name: tension
-          polarity: -1
-          semantic type: event
-      - OntologyNode:
-        examples:
-        - alarm
-        - alerts
-        - early action
-        - early warning
-        - emergency preparedness
-        - false alarm
-        - fews net
-        - fewsnet
-        - forecasting
-        - giews
-        - risk reduction
-        - safety
-        - warning
-        name: early_warning
-        polarity: 1
-        semantic type: event
-      - environmental:
-        - OntologyNode:
-          definition: A prolonged shortage in the water supply.
-          examples:
-          - drought
-          - droughts
-          - low rainfall
-          name: drought
-          polarity: -1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - aftershock
-          - earthquake
-          - earthquakes
-          - tremor
-          - tremors
-          name: earthquake
-          polarity: -1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - acidification
-          - deltas
-          - desertification
-          - environmental degradation
-          - environmental stress
-          - erosion
-          - evaporation
-          - extraction
-          - inundation
-          - overexploitation
-          - salinity
-          - salinization
-          - sedimentation
-          name: environmental_degradation
-          polarity: -1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - flash flood
-          - flood
-          - flooding
-          - storm surge
-          - tsunami
-          name: flood
-          polarity: -1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - cyclones
-          - episodes
-          - event
-          - extremes
-          - hail
-          - heavy
-          - landslides
-          - monsoon
-          - natural disaster
-          - natural disasters
-          - rain
-          - strong winds
-          - tropical cyclones
-          - tsunamis
-          - typhoon
-          - typhoons
-          - weather
-          - winds
-          name: natural_disaster
-          polarity: -1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - cyclone
-          - hurricane
-          - landfall
-          - storm
-          name: storm
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - volcanic eruption
-          - volcano
-          name: volcanic_eruption
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - wild fire
-          - wildfire
-          name: wildfire
-          polarity: -1
-          semantic type: event
-      - OntologyNode:
-        definition: The rapid spread of disease to a large population in a short amount
-          of time.
-        examples:
-        - disease
-        - epidemic
-        - global pandemic
-        - pandemic
-        name: epidemic
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - famine
-        - hunger
-        - starvation
-        name: famine
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - depression
-        - economic crisis
-        - financial crisis
-        - recession
-        name: recession
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - adverse shocks
-        - catastrophe
-        - catastrophic events
-        - climate shocks
-        - climatic shocks
-        - disturbances
-        - external shocks
-        - extreme events
-        - multiple shocks
-        - other shocks
-        - shocks
-        - worse outcomes
-        name: shocks
-        polarity: 1
-        semantic type: event
-    - OntologyNode:
-      examples:
-      - beliefs
-      - cultural norms
-      - social norms
-      - traditions
-      name: cultural_norms
-      polarity: 1
-      semantic type: entity
-    - OntologyNode:
-      examples:
-      - curfew
-      name: curfew
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - discrimination
-      - exclusion
-      - racism
-      - stratification
-      name: discrimination
-      polarity: -1
-      semantic type: event
-    - economy:
-      - OntologyNode:
-        examples:
-        - assets
-        - holdings
-        - land ownership
-        - land property assets
-        - parcels
-        - property
-        - wealth
-        name: assets
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - budget
-        name: budget
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - GDP
-        - GNP
-        - administrations
-        - banks
-        - counterparts
-        - customs
-        - domestic market
-        - domestic markets
-        - downstream markets
-        - employment
-        - formal markets
-        - holders
-        - main market
-        - main markets
-        - major markets
-        - many markets
-        - market disruptions
-        - market sheds
-        - market sites
-        - market supplies
-        - markets
-        - monitored markets
-        - most markets
-        - open markets
-        - other markets
-        - several markets
-        - stock market
-        - urban markets
-        name: commerce
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - business
-        - commercial enterprise
-        - company
-        - corporation
-        name: commercial_enterprise
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - commercial farm
-        - commercial farming
-        - commercial operations
-        - commercial producers
-        - contract farmers
-        - contract growers
-        - enterprises
-        - feedlot
-        - large farmers
-        - large farms
-        - large producers
-        - larger producers
-        - medium enterprises
-        - orchard
-        - outgrowers
-        - plantation
-        - ranch
-        name: commercial_farmers
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - competition
-        name: competition
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - cash
-        - currency
-        - dollar
-        - money
-        - usd
-        name: currency
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - debt
-        - deficit
-        - loan
-        name: debt
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - comparative advantages
-        - economic benefits
-        - economic consequences
-        - economic costs
-        - economic damage
-        - economic effects
-        - economic empowerment
-        - economic factors
-        - economic feasibility
-        - economic gains
-        - economic impact
-        - economic impacts
-        - economic implications
-        - economic importance
-        - economic incentives
-        - economic opportunities
-        - economic reasons
-        - economic shocks
-        - economic situation
-        - economic system
-        - economists
-        - economy
-        - elasticity
-        - monetary impact
-        - moral hazard
-        - outcomes
-        - potential benefits
-        - social benefits
-        - social value
-        name: economy
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - card
-        - consumer prices
-        - currencies
-        - default
-        - disbursements
-        - discount rate
-        - dollar
-        - exchange
-        - exchange rate
-        - interest rate
-        - interest rates
-        - premiums
-        - ratings
-        - reserve
-        - stocking rates
-        - vat
-        name: exchange_rate
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - charge
-        - expense
-        - fee
-        - payment
-        - rent
-        name: expense
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - assets
-        - award
-        - banking
-        - banks
-        - borrowing
-        - capital
-        - card
-        - cards
-        - cash
-        - collateral
-        - cover
-        - credit
-        - creditors
-        - debt
-        - donation
-        - endowment
-        - finance
-        - financial
-        - financial capacity
-        - financial capital
-        - financial institutions
-        - financial markets
-        - financial resources
-        - financial sector
-        - financial services
-        - financial support
-        - fiscal space
-        - funding
-        - grant
-        - invest
-        - investment
-        - lenders
-        - lending
-        - liquidity
-        - loan
-        - microfinance
-        - natural capital
-        - physical capital
-        - social capital
-        - working capital
-        name: finance
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - compensation
-        - earnings
-        - household
-        - income
-        - paycheck
-        - revenue
-        - royalties
-        - salary
-        - wages
-        name: income
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - casual labour
-        - decent work
-        - good job
-        - hard work
-        - hired labour
-        - job activities
-        - labor
-        - labour
-        - labour force
-        - labour market
-        - wage
-        - work
-        - workload
-        - workplace
-        name: labor
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - employment
-        - job
-        - livelihood
-        name: livelihood
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - boxes
-        - brands
-        - butchers
-        - collectors
-        - cooperatives
-        - crates
-        - dealers
-        - distributors
-        - exporters
-        - growers
-        - importers
-        - larger producers
-        - marketers
-        - outlets
-        - packaging
-        - processing
-        - processors
-        - producers
-        - restaurants
-        - retailers
-        - sales
-        - sellers
-        - supermarkets
-        - suppliers
-        - traders
-        - transporters
-        - vendors
-        - wholesalers
-        name: marketing
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - bazaar
-        - grocer
-        - grocery
-        - grocery storage
-        - marketplace
-        - physical market
-        - produce market
-        - retailer
-        - retailers
-        - shop
-        - shopping
-        - stall
-        - store
-        - supermarket
-        - vendor
-        - wet market
-        name: marketplace
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - disbursement
-        - drawdown
-        - payment
-        - payout
-        - remittance
-        - stipend
-        name: payment
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - purchasing power
-        name: purchasing_power
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - entrepreneurs
-        - entrepreneurship
-        - small businesses
-        name: small_businesses
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - farmers
-        - fields
-        - fp farmers
-        - holders
-        - individual farmers
-        - men farmers
-        - pastoralists
-        - peasant
-        - poor farmers
-        - producing households
-        - rural farmers
-        - rural producers
-        - small farmers
-        - small farms
-        - small holders
-        - small producers
-        - smallholder
-        - smallholder farmers
-        - smallholders
-        - smallscale
-        - subsistence farmers
-        - traditional sector
-        - villagers
-        name: small_farmers
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - duties
-        - revenue
-        - subsidies
-        - subsidy
-        - tariff
-        - tax
-        - taxes
-        name: taxes
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - unemployment
-        name: unemployment
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - labor
-        - professionals
-        - staff
-        - worker
-        - workforce
-        name: workforce
-        polarity: 1
-        semantic type: event
-    - OntologyNode:
-      examples:
-      - courses
-      - curriculum
-      - education
-      - instruction
-      - lessons
-      - literacy
-      - mentorship
-      - schooling
-      - trainings
-      - tutoring
-      name: education
-      polarity: 1
-      semantic type: event
-    - entity:
-      - OntologyNode:
-        examples:
-        - african countries
-        - african governments
-        - african leaders
-        - african nations
-        - african societies
-        - african states
-        name: african_governments
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - Harakat al-Shabaab al-Mujahideen
-        - Mujahideen Youth Movement
-        - al shabaab
-        - al-shabaab
-        - al-shabab
-        - hsm
-        name: al-shabaab
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - animal
-        - animal resources
-        - animals
-        - bats
-        - beast
-        - buffalo
-        - buffaloes
-        - bulls
-        - bush
-        - camel
-        - camels
-        - creature
-        - critter
-        - dead animals
-        - dogs
-        - domestic animals
-        - donkeys
-        - goats
-        - horses
-        - indigenous animals
-        - individual animals
-        - infected animals
-        - lamb
-        - large animals
-        - larger animals
-        - long distances
-        - mammals
-        - mice
-        - mules
-        - other animals
-        - pets
-        - piglets
-        - pork
-        - rats
-        - rodents
-        - sick animals
-        - small animals
-        - turkeys
-        - wild animals
-        - wildlife
-        - young animals
-        name: animal
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - artifact
-        name: artifact
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - border
-        - land border
-        name: border
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - drone
-        - drones
-        - uas
-        - uav
-        - unmanned aerial vehicle
-        - unmanned air system
-        - unmanned air vehicle
-        name: drone
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - chirps
-        - climate information
-        - crop monitor
-        - data
-        - field
-        - field reports
-        - ground
-        - ground observations
-        - inputs
-        - observations
-        - regional experts
-        - reports
-        - satellite
-        - weather data
-        name: field_reports
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - gang
-        - gangs
-        name: gangs
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - GPE
-        - city
-        - nation
-        name: geo-political_entity
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - administration
-        - administrations
-        - agency
-        - association
-        - authority
-        - bureau
-        - center
-        - commission
-        - council
-        - departments
-        - directorate
-        - government entity
-        - governorate
-        - implementing agencies
-        - institute
-        - institutes
-        - institution
-        - line ministries
-        - ministry
-        - office
-        - offices
-        - organisation
-        - prefecturates
-        name: government_entity
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - hamas
-        name: hamas
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - agencies
-        - aid
-        - aid workers
-        - behalf
-        - dod
-        - emergency assistance
-        - external assistance
-        - force
-        - foreign aid
-        - form
-        - humanitarian
-        - humanitarian action
-        - humanitarian actors
-        - humanitarian agencies
-        - humanitarian assistance
-        - humanitarian needs
-        - humanitarian operations
-        - humanitarian organizations
-        - humanitarian partners
-        - humanitarian response
-        - humanitarian situation
-        - humanitarian workers
-        - humanitarians
-        - katrina
-        - mission
-        - missions
-        - ngos
-        - receiving
-        - relief
-        - teams
-        - unicef
-        - unsom
-        - unsom officer
-        name: humanitarian_actors
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - indigenous communities
-        - indigenous people
-        name: indigenous_communities
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - global community
-        - international agencies
-        - international institutions
-        - international ngos
-        - international organizations
-        - ngo
-        - ngos
-        name: international_organizations
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - isil
-        - isis
-        name: isil
-        polarity: 1
-        semantic type: entity
-      - locations:
-        - OntologyNode:
-          examples:
-          - big cities
-          - capitals
-          - cities
-          - city
-          - major cities
-          - newspapers
-          - secondary cities
-          - urban areas
-          - urban centers
-          - urban centre
-          - urban markets
-          name: city
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - city
-          - country
-          - geo-location
-          - location
-          name: location
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - neighboring country
-          name: neighboring_country
-          polarity: 1
-          semantic type: entity
-      - OntologyNode:
-        examples:
-        - lord's resistance army
-        - lord's resistance movement
-        - lra
-        name: lord's_resistance_army
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - military exercise
-        - military game
-        - military maneuvers
-        name: military_exercise
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - military
-        - military force
-        - military power
-        name: military_power
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - bilateral donors
-        - development actors
-        - embassies
-        - external assistance
-        - implementing partners
-        - multilateral contributions
-        - multilateral organisations
-        - multilateral system
-        - other partners
-        - sector partners
-        - societies
-        - trading partners
-        - union
-        name: multilateral_system
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - islam
-        - mosque
-        - muslim communities
-        - muslim world
-        - muslims
-        name: muslim_communities
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - external actors
-        - external intervention
-        - nonstate actors
-        - other stakeholders
-        name: nonstate_actors
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - opposition
-        - opposition groups
-        - opposition leaders
-        - opposition parties
-        - opposition party
-        - opposition strongholds
-        - opposition supporters
-        - political adversary
-        - political opponents
-        - political rival
-        name: opposition_party
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - NGO
-        - community based organization
-        - community group
-        - cooperative
-        - organization
-        name: organization
-        polarity: 1
-        semantic type: entity
-      - people:
-        - OntologyNode:
-          examples:
-          - academic
-          - analyst
-          - classmate
-          - expert
-          - faculty
-          - freshman
-          - intellectual
-          - professor
-          - pupil
-          - researcher
-          - scholar
-          - schoolchildren
-          - scientist
-          - sophomore
-          - specialist
-          - student
-          name: academic
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - activist
-          - crowd
-          - demonstrator
-          - protester
-          name: activist
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - adult
-          - elder
-          - elderly
-          - men
-          - senior citizen
-          - women
-          name: adults
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - adviser
-          - advisor
-          - analysts
-          - confidant
-          - consultant
-          - consultants
-          - expert
-          - experts
-          - operators
-          - practitioners
-          - promoters
-          - scientists
-          - specialists
-          - technicians
-          - trainers
-          - volunteers
-          name: adviser
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - adolescent
-          - child
-          - children
-          - juvenile
-          - minor
-          - teenage
-          - teenager
-          - young people
-          - youth
-          name: child_or_youth
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - citizen
-          name: citizen
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - cartel
-          - criminal
-          - mafia
-          - mafioso
-          - pirate
-          - smuggler
-          - syndicate
-          - warlord
-          name: criminal
-          polarity: -1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - captive
-          - detainee
-          - hostage
-          - inmate
-          - prisoner
-          - slave
-          name: detainee
-          polarity: -1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - aristocracy
-          - aristocrat
-          - elite
-          - king
-          - lord
-          - monarch
-          - queen
-          name: elites
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - VEO
-          - crusader
-          - islamist
-          - jihadist
-          - militant
-          - separatist
-          - supremacist
-          - terrorist
-          - vigilante
-          - violent extremist organization
-          name: extremist
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - cowherd
-          - farm worker
-          - farmer
-          - farmhand
-          - goatherd
-          - grazier
-          - pastoralist
-          - rancher
-          - sharecropper
-          - shepherd
-          - smallholder
-          - stockmen
-          name: farm_worker
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - ambassador
-          - attorney general
-          - bureaucrat
-          - congressman
-          - congressperson
-          - congresswoman
-          - consul
-          - diplomat
-          - elected official
-          - envoy
-          - government worker
-          - minister
-          - politician
-          - president
-          - public official
-          - senator
-          name: government_worker
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - CHW
-          - community health worker
-          - doctor
-          - first responders
-          - medic
-          - nurse
-          - nursing
-          - physicians assistant
-          name: health_worker
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - clans
-          - displaced households
-          - families
-          - family
-          - family compound
-          - household
-          - individual households
-          - large households
-          - many families
-          - many households
-          - most households
-          - poorest households
-          - producing households
-          - wealthier households
-          name: household
-          pattern:
-          - household
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - baby
-          - infant
-          - newborn
-          name: infant
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - landholder
-          - landlord
-          - landowner
-          name: landowner
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - law enforcement
-          - local officials
-          - local police
-          - police
-          - police forces
-          - police officer
-          - security officials
-          name: law_enforcement_officials
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - maternal
-          - mother
-          - mothers
-          name: maternal
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - husband
-          - man
-          - men
-          name: men
-          polarity: 1
-          semantic type: entity
-        - migration:
-          - OntologyNode:
-            examples:
-            - IDP
-            - displaced person
-            - returnee
-            name: displaced_person
-            polarity: 1
-            semantic type: entity
-          - OntologyNode:
-            examples:
-            - economic migrant
-            - migrant
-            name: migrant
-            polarity: -1
-            semantic type: entity
-          - OntologyNode:
-            examples:
-            - asylum seeker
-            - refugee
-            - returnee
-            name: refugee
-            polarity: 1
-            semantic type: entity
-        - OntologyNode:
-          examples:
-          - admiral
-          - armed forces
-          - armies
-          - army
-          - battalion
-          - colonel
-          - commander
-          - general
-          - lieutenant
-          - militants
-          - military
-          - officer
-          - regiment
-          - soldier
-          - troops
-          name: military_personnel
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - militia
-          name: militia
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - anchor
-          - blogger
-          - broadcaster
-          - correspondent
-          - journalist
-          - news anchor
-          - newsmedia
-          - reporter
-          name: newsmedia
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - observer
-          - watchdog
-          name: observer
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - community
-          - group
-          - person or group
-          - society
-          - village
-          name: person_or_group
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - insurgents
-          - militant group
-          - rebel group
-          name: rebels
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - task force
-          - taskforce
-          name: taskforce
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - voter
-          name: voter
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - bride
-          - female farmers
-          - females
-          - girls
-          - mothers
-          - wife
-          - wives
-          - woman
-          - women
-          - women farmers
-          name: women
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - young adults
-          - young men
-          - young women
-          name: young_adults
-          polarity: 1
-          semantic type: entity
-      - OntologyNode:
-        examples:
-        - church
-        - congregation
-        - parish
-        - seminary
-        name: religious_entity
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        definition: 'note: in Kenya, the ruling party is the Jubilee party'
-        examples:
-        - incumbent
-        - incumbent government
-        - jubilee party
-        - ruling coalition
-        - ruling party
-        name: ruling_party
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - communes
-        - farmlands
-        - rural
-        - rural areas
-        - rural communities
-        - rural development
-        - rural economies
-        - rural households
-        - rural incomes
-        - rural livelihoods
-        - rural markets
-        - rural populations
-        - rural producers
-        - rural regions
-        - rural roads
-        - rural sector
-        - rural villages
-        - subsistence
-        name: rural_households
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - cities
-        - city
-        - city center
-        - rural settings
-        - slums
-        - urban
-        - urban areas
-        - urban centers
-        - urban communities
-        - urban households
-        - urban markets
-        - urban populations
-        - urban residents
-        - urban settings
-        name: urban_households
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - SUV
-        - aeroplane
-        - airplane
-        - ambulance
-        - automobile
-        - bicycle
-        - bike
-        - boat
-        - bus
-        - car
-        - helicopter
-        - motorcycle
-        - tractor
-        - train
-        - truck
-        - van
-        - vehicle
-        name: vehicle
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - ammunition
-        - explosives
-        - firearms
-        - guns
-        - light weapons
-        - small arms
-        - weapons
-        name: weapons
-        polarity: 1
-        semantic type: entity
-    - environment:
-      - OntologyNode:
-        examples:
-        - climate
-        name: climate
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - changing climate
-        - climate
-        - climate action
-        - climate change
-        - climate extremes
-        - climate impacts
-        - climate migration
-        - climate models
-        - climate resilience
-        - climate risks
-        - climate science
-        - climate security
-        - climate shocks
-        - climate variability
-        - climatic change
-        - deforestation
-        - emissions scenarios
-        - environmental change
-        - ghg
-        - global change
-        - global warming
-        - human activity
-        - human factors
-        - natural systems
-        name: climate_change
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - biodiversity
-        - ecology
-        - ecosystem
-        - habitat
-        - riparian
-        - wildlife
-        name: ecology
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - aerosol
-        - aerosols
-        - air
-        - anthropogenic emissions
-        - atmosphere
-        - emission factors
-        - emission reductions
-        - evapotranspiration
-        - heatwave
-        - lungs
-        - ozone
-        - radiation
-        - solar radiation
-        - surface air
-        - thermocline
-        - thermotolerance
-        - tropospheric ozone
-        name: emissions
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - environmental impacts
-        name: environmental_impacts
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - afforestation
-        - agroforestry
-        - biodiversity
-        - deforestation
-        - forest
-        - forest area
-        - forest cover
-        - forest degradation
-        - forest products
-        - forest resources
-        - forestry
-        - forests
-        - logging
-        - mangroves
-        - protected areas
-        - reforestation
-        - terrestrial ecosystems
-        - timber
-        - tree
-        - vegetation
-        name: forestry
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - climate changes
-        - degrees
-        - drier
-        - extreme heat
-        - extreme temperatures
-        - heat
-        - heat stress
-        - heat waves
-        - high temperatures
-        - higher temperatures
-        - rising temperatures
-        - temperature increases
-        - temperatures
-        - warmer temperatures
-        name: higher_temperatures
-        polarity: 1
-        semantic type: event
-      - meteorology:
-        - OntologyNode:
-          examples:
-          - precipitation
-          - rain
-          - rainfall
-          - storm
-          name: precipitation
-          polarity: 1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - temperature
-          name: temperature
-          polarity: 1
-          semantic type: event
-        - OntologyNode:
-          definition: The state of the atmosphere, describing the degree to which
-            it is hot or cold, wet or dry, calm or stormy, clear or cloudy.
-          examples:
-          - climate variability
-          - extreme winds
-          - humid
-          - rainfall
-          - rains
-          - snow
-          - storm
-          - weather
-          - weather systems
-          - wet
-          - wetter
-          name: weather
-          polarity: 1
-          semantic type: event
-      - natural_resources:
-        - OntologyNode:
-          definition: Fuels formed from natural processes, containing organic molecules,
-            that release energy in combustion.
-          examples:
-          - carbon
-          - crude oil
-          - fossil fuels
-          - natural gas
-          - oil
-          name: fossil_fuels
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - groundwater
-          name: groundwater
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - acreage
-          - arable land
-          - farmland
-          - forestland
-          - land
-          - land resources
-          - plot
-          name: land
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          definition: Land used for grazing by domesticated livestock.
-          examples:
-          - grazing
-          - pastoral
-          - pasture
-          - rangeland
-          - vegetation
-          name: pasture
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - leaching into the soil
-          - soil
-          - soil types
-          name: soil
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - aqueduct
-          - lake
-          - ocean
-          - pond
-          - reservoir
-          - river
-          - water bodies
-          name: water_bodies
-          polarity: 1
-          semantic type: entity
-      - OntologyNode:
-        examples:
-        - air pollution
-        - contamination
-        - greenhouse gas
-        - land pollution
-        - water pollution
-        name: pollution
-        polarity: -1
-        semantic type: event
-    - OntologyNode:
-      examples:
-      - ethnic diversity
-      - ethnic minorities
-      name: ethnic_diversity
-      polarity: 1
-      semantic type: entity
-    - OntologyNode:
-      examples:
-      - freedom
-      name: freedom
-      polarity: 1
-      semantic type: event
-    - goods:
-      - agricultural:
-        - OntologyNode:
-          examples:
-          - compound feed
-          - compound poultry feed
-          - concentrate feed
-          - micronutrients
-          - oil cakes
-          - supplemental feed
-          name: compound_feed
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - farm equipment
-          - machinery
-          - plow
-          - power tiller
-          - row planter
-          - tractor
-          - winnower
-          name: farm_equipment
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - CSB
-          - corn meal
-          - hay
-          - livestock feed
-          - poultry feed
-          - silage
-          - soybean hulls
-          name: feed
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - DAP
-          - compost
-          - fertilizer
-          - manure
-          - nitrogen
-          - phosphorous
-          - potassium
-          - urea
-          name: fertilizer
-          pattern:
-          - \b(manure|fertilizers?|nitrogen)\b
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - drip
-          - electric pump
-          - field irrigation
-          - irrigation equipment
-          - pump
-          - small scale irrigation pump
-          - sprinklers
-          - treadle
-          - water pumps
-          name: irrigation_equipment
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - animal production
-          - beef
-          - bone meal
-          - bovine meat
-          - broiler meat
-          - capita meat
-          - carcass weight
-          - chicken breast
-          - chicken feet
-          - chicken leg
-          - chicken meat
-          - chicken thigh
-          - commercial sector
-          - concept meat
-          - cultured meat
-          - dog
-          - fowl meat
-          - game
-          - goat meat
-          - livestock prices
-          - livestock products
-          - meat
-          - meat chickens
-          - meat exports
-          - meat imports
-          - meat industry
-          - meat meal
-          - meat output
-          - meat prices
-          - meat products
-          - meat sector
-          - meat yield
-          - meats
-          - more meat
-          - mutton
-          - offal
-          - other animals
-          - other foods
-          - other meat
-          - other meats
-          - ovine meat
-          - pig meat
-          - piglets
-          - pigmeat
-          - pork
-          - poultry meat
-          - processed meat
-          - red meat
-          - slaughter houses
-          - slaughterhouse
-          - slaughterhouses
-          - total meat
-          - turkeys
-          - white meat
-          - wild foods
-          name: meat
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - IPM
-          - chemical
-          - integrated pest management
-          - organic
-          - pesticide
-          name: pesticide
-          pattern:
-          - \b(DDT|dicamba|round-up)\b
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - GMO
-          - heirloom seed
-          - improved seed
-          - organic seed
-          - seed
-          name: seed
-          polarity: 1
-          semantic type: entity
-      - OntologyNode:
-        examples:
-        - concrete cement
-        - construction materials
-        - lumber
-        name: construction_materials
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - chalkboard
-        - education supplies
-        - notebook
-        - pencil
-        - smartboard
-        - textbooks
-        name: education_supplies
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - bread
-        - breakfast
-        - broken rice
-        - butter
-        - cooking
-        - diet
-        - dietary
-        - dish
-        - dishes
-        - food
-        - garlic
-        - herbs
-        - meals
-        - meat meal
-        - menu
-        - mixed dishes
-        - noodles
-        - onion
-        - onions
-        - pasta
-        - plates
-        - potato
-        - potatoes
-        - refrigerator
-        - restaurant
-        - rice bran
-        - salt
-        - snacks
-        - soybean meal
-        - spices
-        - sweet potatoes
-        - tomatoes
-        name: food
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - fuel
-        - gas
-        - oil
-        name: fuel
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - bandages
-        - bed
-        - blood
-        - medical supplies
-        - respirator
-        - ventilator
-        name: medical_supplies
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - antibiotics
-        - antimicrobial
-        - antiretroviral
-        - antiviral
-        - antivirals
-        - aspirin
-        - corticosteroid
-        - drugs
-        - medication
-        - medicine
-        - paracetamol
-        - penicillin
-        - pharmaceuticals
-        - steroid
-        - tetracycline
-        - therapeutic
-        name: medicine
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - aluminium
-        - aluminum
-        - cobalt
-        - copper
-        - diamond
-        - gold
-        - metal
-        - mineral
-        - ore
-        - silver
-        - zinc
-        name: minerals
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - clean water
-        - drinking water
-        - fresh water
-        - potable water
-        - safe water
-        - water quality
-        name: potable_water
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - alfalfa
-        - bean
-        - dairy
-        - eggs
-        - fishmeal
-        - groundnut
-        - groundnuts
-        - legume
-        - meat
-        - milk
-        - sorghum
-        - soy
-        - soya
-        - soya bean
-        - soybean
-        - soybean cake
-        - soybean cakes
-        - soybean meal
-        - soybeans
-        - sunflower
-        - tilapia
-        - yoghurt
-        - yogurt
-        name: protein_foods
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - H20
-        - aqua
-        - water
-        name: water
-        polarity: 1
-        semantic type: entity
-    - government:
-      - corruption:
-        - corrupt_policy:
-          - OntologyNode:
-            examples:
-            - cronyism
-            - favoritism
-            - nepotism
-            - party corruption
-            - policy favoritism
-            - political clientelist network
-            - political patronage
-            name: cronyism
-            polarity: 1
-            semantic type: event
-          - OntologyNode:
-            examples:
-            - campaign financing irregularities
-            - conflict of interest
-            - illegal contributions
-            - illicit contributions
-            - illicit political financing
-            name: illicit_political_financing
-            polarity: 1
-            semantic type: entity
-          - OntologyNode:
-            examples:
-            - bribery
-            - corrupt parliamentary oversight
-            - dereliction of duty
-            - fiscal irresponsibility
-            - parliamentary corruption
-            - parliamentary vote selling
-            - rent extraction
-            - rent seeking
-            name: parliamentary_corruption
-            polarity: 1
-            semantic type: entity
-        - OntologyNode:
-          examples:
-          - ballot burning
-          - ballot stuffing
-          - corrupt campaigning
-          - deceptive campaign techniques
-          - election fraud
-          - election manipulation
-          - electoral fraud
-          - illegal campaigning
-          - rigged election
-          - violation of campaign laws
-          - vote buying
-          - vote manipulation
-          - voter fraud
-          - voter intimidation
-          - voter oppression
-          name: election_manipulation
-          polarity: 1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - arbitrary arrests
-          - bribery
-          - corruption
-          - disappearances
-          - extrajudicial killings
-          - impunity
-          name: government_corruption
-          polarity: 1
-          semantic type: event
-      - OntologyNode:
-        examples:
-        - decentralization
-        - decentralize
-        name: decentralization
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - foreign affairs
-        - international affairs
-        - international relations
-        - international security
-        name: diplomatic_relations
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - ballot
-        - caucus
-        - election
-        - referendum
-        - voting
-        name: election
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - election cycle
-        - election process
-        - electoral cycle
-        - electoral process
-        - electoral system
-        name: election_process
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - diplomats
-        - foreign affairs
-        - foreign aid
-        - foreign policy
-        - foreign relations
-        - international security
-        - political science
-        name: foreign_policy
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - census
-        - policy
-        - program
-        - psnp
-        - safety net
-        - social security
-        name: government_program
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - court system
-        - courthouse
-        - judicial
-        - judiciary
-        - supreme court
-        - tribunal
-        name: judicial_system
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - act
-        - appropriate policies
-        - bill
-        - bills
-        - congress
-        - constitution
-        - directives
-        - existing policies
-        - filed
-        - frameworks
-        - laws
-        - legislation
-        - legislations
-        - policies
-        - priorities
-        - provisions
-        - regulations
-        - regulatory frameworks
-        - schedules
-        - sector policies
-        name: legislation
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - political influence
-        - political power
-        name: political_power
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - authoritarianism
-        - autocracy
-        - democracy
-        - dictatorship
-        - hegemony
-        - imperialism
-        - political
-        - politics
-        - reforms
-        - regime
-        - reign
-        name: political_system
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - polling staff
-        - polling station
-        - polling stations
-        name: polling_stations
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        definition: A restriction on trade, or measures by a country on a state or
-          individual intended to elicit a change in their behavior.
-        examples:
-        - sanction
-        name: sanction
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - failed states
-        - state collapse
-        - state failure
-        name: state_collapse
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - central authority
-        - congressional power
-        - executive power
-        - judicial power
-        - parliamentary power
-        - state authority
-        - state control
-        - state institutions
-        - state power
-        - state-building
-        name: state_power
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - government change
-        name: transition_of_power
-        polarity: 1
-        semantic type: event
-    - health:
-      - OntologyNode:
-        examples:
-        - antibodies
-        - antibody
-        - antigens
-        name: antibody
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - DNA
-        - biometrics
-        - fingerprint
-        name: biometrics
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - caseload
-        - confirmed cases
-        - disease cases
-        - new cases
-        - reported cases
-        - severe cases
-        - suspected cases
-        name: case_volume
-        pattern:
-        - \b(case\s+volume)\b
-        - \b(new\s+cases)\b
-        polarity: -1
-        semantic type: event
-      - disease:
-        - OntologyNode:
-          examples:
-          - aids
-          - hiv
-          name: AIDS
-          polarity: -1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - corona virus
-          - coronavirus
-          - novel coronavirus
-          - virus
-          name: COVID
-          pattern:
-          - (COVID|covid|SARS-CoV)
-          - corona(\s+)?virus
-          polarity: -1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - flu
-          - influenza
-          name: flu
-          polarity: -1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - anaemia
-          - cancer
-          - chikunguya
-          - congestion
-          - diarrhea
-          - episodes
-          - gross lesions
-          - illness
-          - inflammation
-          - lesions
-          - measles
-          - mers
-          - organs
-          - pathology
-          - pox
-          - salmonella
-          - sars
-          - sickness
-          - survivors
-          - tb
-          - tissue
-          - tsetse
-          - tuberculosis
-          - vessels
-          - zika
-          name: illness
-          polarity: -1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - malaria
-          name: malaria
-          polarity: -1
-          semantic type: event
-      - OntologyNode:
-        examples:
-        - alleles
-        - carriers
-        - clade
-        - gene
-        - genes
-        - genetic characterization
-        - genetic distance
-        - genetic improvement
-        - genetic material
-        - genetic potential
-        - genetic resistance
-        - genetic resources
-        - genetic selection
-        - genetic variation
-        - genome
-        - locus
-        - major genes
-        - markers
-        - mutation
-        - mutations
-        - phenotypes
-        - snps
-        name: gene
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - health
-        - healthcare
-        - medical
-        name: healthcare
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - PPE
-        - face covering
-        - hand sanitizer
-        - hygiene materials
-        - masks
-        - personal protective equipment
-        - soap
-        name: hygiene_materials
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - injury
-        - wound
-        name: injury
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - assessments
-        - characterization
-        - diagnostic confirmation
-        - diagnostic tests
-        - diagnostics
-        - examination
-        - further analysis
-        - inspection
-        - investigation
-        - isolation
-        - lab
-        - laboratories
-        - laboratory
-        - laboratory testing
-        - monitor
-        - pcr
-        - probe
-        - records
-        - sample collection
-        - screening
-        - separation
-        - sequencing
-        - test
-        - testing
-        - tests
-        name: laboratory_testing
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - life
-        - lives
-        - living
-        name: life
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - acute malnutrition
-        - gam
-        - gam whz
-        - global acute malnutrition
-        - haz
-        - hdds
-        - height for age
-        - hhs
-        - household dietary diversity score
-        - household hunger scale
-        - hunger
-        - malnourished
-        - stunting
-        - wasting
-        - weight for height
-        - whz
-        name: malnutrition
-        polarity: -1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - DALY
-        - disability
-        - disability adjusted life year
-        - high morbidity
-        - morbidity
-        name: morbidity
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - adequate amounts
-        - bioavailability
-        - calories
-        - carbohydrates
-        - chemicals
-        - cholesterol
-        - compounds
-        - diets
-        - ectoparasites
-        - energy
-        - essential micronutrients
-        - essential nutrients
-        - ethiochicken
-        - folate
-        - ingredient
-        - iodine
-        - ldc
-        - lysine
-        - macronutrients
-        - metabolism
-        - methionine
-        - micronutrient adequacy
-        - mycotoxins
-        - nutrient
-        - nutrient requirements
-        - nutrients
-        - oils
-        - other components
-        - other nutrients
-        - phosphorus
-        - protein
-        - quantities
-        - reagents
-        - requirement
-        - requirements
-        - riboflavin
-        - selenium
-        - substances
-        - supplementation
-        - supplements
-        - threonine
-        - vitamin
-        - vitamin a
-        - vitamins
-        name: nutrients
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - bioavailability
-        - diet
-        - nutrient content
-        - nutrition outcomes
-        - nutritional needs
-        - nutritional requirements
-        - nutritional value
-        - obesity
-        name: nutrition
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - bacteria
-        - bacterium
-        - bovine brucellosis
-        - brucellosis
-        - contagions
-        - cysts
-        - echinococcosis
-        - external parasites
-        - fomites
-        - fungal
-        - fungus
-        - germplasm
-        - germs
-        - microbe
-        - mycobacterium
-        - mycoplasmosis
-        - mycotoxins
-        - parasite
-        - pathogen
-        - pathogens
-        - salmonella
-        - salmonellosis
-        - toxins
-        - trypanosomes
-        - virus
-        - zoonotic pathogens
-        name: pathogen
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - child mortality
-        - child stunting
-        - infant mortality
-        - lbw
-        - stunting
-        name: poor_childrens_health
-        polarity: -1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - crude protein
-        - protein
-        - protein content
-        - protein requirements
-        - protein source
-        - protein sources
-        name: protein_nutrient
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - population health
-        - public health
-        name: public_health
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - public safety
-        name: public_safety
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - alcohol abuse
-        - cocaine
-        - drugs abuse
-        - heroin
-        - narcotics
-        - prescription drug abuse
-        - substance abuse
-        name: substance_abuse
-        polarity: -1
-        semantic type: event
-      - treatment:
-        - OntologyNode:
-          examples:
-          - intensive care
-          name: intensive_care
-          polarity: 1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - preventative treatment
-          - prophylactic
-          - vaccine
-          - well visit
-          name: preventative_treatment
-          polarity: 1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - anti-depressant
-          - counseling
-          - psychiatrist
-          - psychological services
-          - psychotherapy
-          - therapy
-          name: psychological_services
-          polarity: 1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - additional feed
-          - cumulative feed
-          - feed
-          - feed conversion
-          - feed requirements
-          - feed resources
-          - feed supplementation
-          - feed supplements
-          - improved feed
-          - more feed
-          - supplemental feed
-          - supplementary feed
-          - supplementary feeding
-          name: supplemental_feed
-          polarity: 1
-          semantic type: event
-      - OntologyNode:
-        examples:
-        - cell
-        - covax
-        - immunization
-        - inoculation
-        - ndv vaccines
-        - recombinant vaccines
-        - strain
-        - syringe
-        - syringes
-        - vaccinated
-        - vaccination
-        - vaccinations
-        - vaccinator
-        - vaccinators
-        - vaccine
-        - vat
-        - virology
-        name: vaccination
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        definition: An agent that carries or transmits an infectious pathogen into
-          another living organism.
-        examples:
-        - excrement
-        - mosquitos
-        - transmission
-        - vector
-        - water
-        name: vector
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - body size
-        - body weight
-        - body weights
-        - bone
-        - carcass characteristics
-        - conversion ratio
-        - function
-        - growth
-        - muscle
-        - weight
-        - weight gain
-        - weight loss
-        - weights
-        name: weight_gain
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - living condition
-        - welfare
-        name: welfare
-        polarity: 1
-        semantic type: event
-    - OntologyNode:
-      examples:
-      - homeless
-      name: homelessness
-      polarity: -1
-      semantic type: entity
-    - OntologyNode:
-      examples:
-      - freedom
-      - freedoms
-      - human rights
-      - liberties
-      - liberty
-      name: human_rights
-      polarity: 1
-      semantic type: event
-    - humanitarian_assistance:
-      - OntologyNode:
-        examples:
-        - CSB
-        - food aid
-        - food for work
-        - free food distribution
-        - nutrition assistance
-        - ration
-        - school feeding
-        name: food_aid
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - development assistance
-        - emergency aid
-        - emergency response
-        - foreign assistance
-        - humanitarian aid
-        - humanitarian assistance
-        - humanitarian interventions
-        - international aid
-        - urgent assistance
-        name: humanitarian_assistance
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - NFI
-        - buckets
-        - jerry can
-        - non food items
-        - pans
-        - pots
-        - soap
-        - tarp
-        name: non_food_items
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - cash assistance
-        - food voucher
-        - livelihood assistance
-        - voucher or cash
-        name: voucher_or_cash
-        pattern:
-        - \bcash\b
-        - \bvouchers?\b
-        polarity: 1
-        semantic type: event
-    - OntologyNode:
-      examples:
-      - discrepancy
-      - disparity
-      - imbalance
-      - inequality
-      - inequity
-      name: inequality
-      polarity: -1
-      semantic type: event
-    - information:
-      - OntologyNode:
-        examples:
-        - computers
-        - digital technologies
-        - information technology
-        name: information_technology
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - intelligence
-        - intelligence analysis
-        - intelligence information
-        name: intelligence_information
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - internet
-        - mobile internet
-        - web
-        - world wide web
-        name: internet
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - disinformation
-        - fake news
-        - false reporting
-        - falsehood
-        - misconception
-        - misinformation
-        - misreporting
-        name: misinformation
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - allegation
-        - myth
-        - narrative
-        - rumor
-        - rumour
-        - speculation
-        name: rumor
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - facebook
-        - instagram
-        - social media
-        - twitter
-        name: social_media
-        polarity: 1
-        semantic type: entity
-    - infrastructure:
-      - agriculture:
-        - OntologyNode:
-          examples:
-          - barn
-          - farm infrastructure
-          - greenhouse
-          - livestock enclosure
-          - nursery
-          - post harvest infrastructure
-          name: farm_infrastructure
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - agricultural land
-          - arable land
-          - farmland
-          name: farmland
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - broiler producers
-          - poultry producers
-          - salvage slaughter
-          - slaughter
-          - slaughter facilities
-          - slaughter houses
-          - slaughterhouse
-          - slaughterhouses
-          - slaughtering
-          name: slaughterhouse
-          polarity: 1
-          semantic type: entity
-      - OntologyNode:
-        examples:
-        - advertisement
-        - article
-        - bandwidth
-        - booklet
-        - channel
-        - communication
-        - email
-        - facebook
-        - forum
-        - intranet
-        - magazine
-        - media
-        - networking
-        - news
-        - newsgroup
-        - newspaper
-        - online
-        - pamphlet
-        - poster
-        - publication
-        - speech
-        - telecom
-        - telecommunications
-        - telephone
-        - television
-        name: communication
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - campus
-        - child friendly learning spaces
-        - classroom
-        - college
-        - community centers
-        - education facilities
-        - faculty
-        - institute
-        - kindergarten
-        - lecture hall
-        - school
-        - university
-        name: education_facilities
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - electrical wiring
-        - electricity
-        - generator
-        - lighting
-        - power grid
-        - power line
-        - solar panel
-        name: electrical_infrastructure
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - electricity
-        - energy
-        - hydropower
-        - wind power
-        name: energy
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - dam
-        - energy
-        - generator
-        - micro grid
-        - power plant
-        - power station
-        - solar panel
-        - wind turbine
-        name: energy_infrastructure
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - dike
-        - flood wall
-        - levee
-        - seawall
-        name: flood_mitigation_infrastructure
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - buildings
-        - floors
-        - housing
-        - roof
-        - roofs
-        - rooms
-        - walls
-        - windows
-        name: housing
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - canal
-        - irrigation
-        name: irrigation_infrastructure
-        pattern:
-        - irrigation
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - basic health services
-        - care facilities
-        - care services
-        - care system
-        - care workers
-        - clinic
-        - doctors office
-        - field hospitals
-        - health centre
-        - health facility
-        - health post
-        - hospital
-        - medical facilities
-        - mobile clinics
-        name: medical_facilities
-        pattern:
-        - \bclinics\b
-        - \bhospitals?\b
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - mine
-        - mineshaft
-        name: mining_infrastructure
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - idp camps
-        - refugee camp
-        - refugee settlements
-        - temporary housing
-        name: refugee_camps
-        pattern:
-        - \bcamps?\b
-        - \brefugee\s+camps?\b
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - handwashing station
-        - latrines
-        - sanitation
-        - toilets
-        name: sanitation_infrastructure
-        pattern:
-        - \blatrines?\b
-        - \btoilets?\b
-        polarity: 1
-        semantic type: entity
-      - transportation:
-        - OntologyNode:
-          examples:
-          - bridge
-          name: bridge
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - public transport
-          - public transportation
-          name: public_transportation
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - rail
-          - railroad
-          - train
-          name: railroad_infrastructure
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - highway
-          - road
-          - trucking
-          - trucks
-          name: road_infrastructure
-          polarity: 1
-          semantic type: entity
-      - OntologyNode:
-        examples:
-        - ballot boxes
-        - polling booths
-        - voting locations
-        - voting systems
-        - voting tools
-        name: voting_infrastructure
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - boreholes
-        - water facilities
-        - water point
-        - water treatment center
-        - wells
-        name: water_facilities
-        pattern:
-        - \bborehole
-        polarity: 1
-        semantic type: entity
-    - OntologyNode:
-      examples:
-      - appropriate technologies
-      - different approaches
-      - existing technologies
-      - improved technologies
-      - innovations
-      - innovative approaches
-      - modern technologies
-      - new approach
-      - new approaches
-      - new ideas
-      - new markets
-      - new practices
-      - new technologies
-      - new technology
-      - new tools
-      - new ways
-      - technologies
-      name: innovation
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - approaches
-      - appropriate actions
-      - appropriate interventions
-      - appropriate technologies
-      - choices
-      - different interventions
-      - different strategies
-      - efforts
-      - intervention
-      - intervention options
-      - intervention strategies
-      - interventions
-      - other interventions
-      - other methods
-      - participatory approaches
-      - possible solutions
-      - programmes
-      - project interventions
-      - proposed interventions
-      - solutions
-      - specific interventions
-      - strategies
-      - such efforts
-      - such interventions
-      - such programmes
-      - tactics
-      - tools
-      - traditional methods
-      - wash interventions
-      name: intervention
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - literacy
-      name: literacy
-      polarity: 1
-      semantic type: entity
-    - OntologyNode:
-      examples:
-      - antimicrobials
-      - biotechnologies
-      - biotechnology
-      - fungi
-      - gram
-      - microbes
-      - microbiology
-      - microorganisms
-      - organism
-      - probiotics
-      - termites
-      name: microbiology
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - opinion
-      - perception
-      - perceptions
-      name: perception
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - action
-      - action plan
-      - agenda
-      - climate plan
-      - development strategy
-      - horizon
-      - initiative
-      - master
-      - national policy
-      - new deal
-      - path
-      - plan
-      - priority
-      - program
-      - response plan
-      - roadmap
-      - roadmaps
-      - strategic plan
-      - strategic planning
-      - transformation plan
-      - vision
-      - work plans
-      name: plan
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - decision making
-      - policy
-      - policy changes
-      - policy interventions
-      - policy makers
-      - policymaking
-      name: policy_making
-      polarity: 1
-      semantic type: event
-    - population_demographics:
-      - OntologyNode:
-        examples:
-        - age
-        name: age
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - clan
-        - family
-        name: clan
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - ethnic identities
-        - ethnic identity
-        - identities
-        - identity
-        - identity groups
-        name: ethnic_identity
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - empowerment
-        - equal opportunities
-        - female
-        - gender
-        - gender analysis
-        - gender demographics
-        - gender dimensions
-        - gender equality
-        - gender focus
-        - gender issues
-        - inclusiveness
-        - male
-        - sex
-        - sexes
-        - social determinants
-        name: gender
-        polarity: 1
-        semantic type: entity
-      - population_density:
-        - OntologyNode:
-          examples:
-          - de-population
-          - depopulation
-          - population decline
-          name: de-population
-          polarity: -1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - overcrowding
-          name: overcrowding
-          polarity: 1
-          semantic type: entity
-        - OntologyNode:
-          examples:
-          - population growth
-          name: population_growth
-          polarity: 1
-          semantic type: entity
-      - OntologyNode:
-        examples:
-        - ethnicity
-        - race
-        name: race_or_ethnicity
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - religion
-        name: religion
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - ethnicity
-        - tribal
-        - tribe
-        name: tribe
-        polarity: 1
-        semantic type: entity
-    - OntologyNode:
-      examples:
-      - poor communities
-      - poor consumers
-      - poor countries
-      - poor families
-      - poor households
-      - poorer households
-      - poorest households
-      - poverty
-      name: poverty
-      polarity: -1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - bans
-      - ceilings
-      - controls
-      - cuts
-      - penalties
-      - regulations
-      - related restrictions
-      - restrictions
-      - restrictive measures
-      - sanctions
-      name: regulations
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - celebration
-      - ceremony
-      - commemoration
-      - festival
-      - funeral
-      - holiday
-      - observance
-      - ritual
-      name: ritual
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - basic services
-      - civil registration
-      - entitlements
-      - essential services
-      - pensions
-      - social assistance
-      - social benefits
-      - social protection
-      - social services
-      - vouchers
-      - welfare
-      name: safety_net
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - carcasses
-      - culling
-      - spoilage
-      name: scavenging_system
-      polarity: 1
-      semantic type: event
-    - security:
-      - OntologyNode:
-        examples:
-        - community
-        - mine clearance
-        - policing
-        name: community_security
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - depreciation
-        - economic security
-        - economy
-        - inflation
-        - recession
-        name: economic_security
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - environmental security
-        name: environmental_security
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - diplomacy
-        - military
-        - national security
-        name: national_security
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - informant
-        - monitor
-        - spy
-        - surveillance system
-        - track
-        name: surveillance_system
-        polarity: 1
-        semantic type: event
-    - OntologyNode:
-      examples:
-      - cultural factors
-      - individual characteristics
-      - marital status
-      - personal relationships
-      - power relations
-      - social capital
-      - social cohesion
-      - social factors
-      - social groups
-      - social interactions
-      - social networks
-      - social practices
-      - social relations
-      - social relationships
-      - social sciences
-      - social scientists
-      - social status
-      - social structure
-      - social systems
-      - symbolic boundaries
-      - ties
-      name: social_structure_or_relationship
-      polarity: 1
-      semantic type: event
-    - storage:
-      - OntologyNode:
-        examples:
-        - agricultural storage
-        - granary
-        - silo
-        - warehouse
-        name: agricultural_storage
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - storage
-        - storage facilities
-        - warehouse
-        name: general_storage_facilities
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - household food storage
-        - storage
-        name: household_food_storage
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - stockpile
-        name: stockpile_goods
-        polarity: 1
-        semantic type: entity
-    - time:
-      - OntologyNode:
-        examples:
-        - delay
-        - halt
-        - postpone
-        - stall
-        - suspend
-        name: delay
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - arid
-        - drought
-        - dry season
-        - dry spells
-        - drylands
-        - summer
-        name: dry_season
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - ongoing
-        - prolonged
-        - protracted
-        name: prolonged
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - crop calendar
-        - crop season
-        - harvesting season
-        - lean season
-        - planting season
-        - season
-        name: season
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - long rains
-        - monsoon
-        - rainfall
-        - rainy seasons
-        - wet
-        - wet seasons
-        name: wet_season
-        polarity: 1
-        semantic type: event
-    - OntologyNode:
-      examples:
-      - bias
-      - demographics
-      - fluctuations
-      - pattern
-      - percentage change
-      - trend
-      name: trend
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - attendance
-      - turnout
-      name: turnout
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - urbanization
-      name: urbanization
-      polarity: 1
-      semantic type: event
-  - process:
-    - OntologyNode:
-      definition: The ability or right to approach, enter, exit, make use of, or communicate
-        with something.
-      examples:
-      - access
-      name: access
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - adapt
-      - adaptability
-      - adaptation
-      - flexibility
-      name: adapt
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - aid
-      - assist
-      - assistance
-      - help
-      - support
-      name: aid_or_assistance
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - analyze
-      - assess
-      - critique
-      - evaluate
-      name: assessment
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - attempt
-      - campaign
-      - effort
-      - initiative
-      - program
-      - try
-      name: attempt
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - breed
-      - breeder
-      - breeding
-      - brooder
-      - broodiness
-      - brooding
-      - chick survival
-      - cocks
-      - crossbred
-      - crossbreed
-      - crossbreeding
-      - domestication
-      - egg offtake
-      - egg size
-      - generation
-      - grandparent stock
-      - growing phase
-      - hatchability
-      - hatchery
-      - hatching
-      - inbreeding
-      - laying
-      - laying hens
-      - mating
-      - maturation
-      - next generation
-      - offspring
-      - parent stock
-      - phenotype
-      - progeny
-      - rearers
-      - rearing
-      - reproductive stages
-      - roosters
-      - semen
-      - stud
-      name: breeding
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - censorship
-      name: censorship
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - clean
-      - clean up
-      - cleanse
-      - sanitization
-      - sanitize
-      - wash
-      name: clean
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - alliance
-      - allied
-      - ally
-      - coalition
-      - collaborate
-      - collaboration
-      - cooperate
-      - partner
-      - partnership
-      name: collaboration
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - collect
-      - collecting
-      - collection
-      - compile
-      - gather
-      - hoard
-      name: collecting
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - combine
-      - couple
-      - incorporate
-      - integrate
-      - link
-      - merge
-      - mix
-      name: combining
-      polarity: 1
-      semantic type: event
-    - communication:
-      - ask:
-        - OntologyNode:
-          examples:
-          - canvass
-          - poll
-          name: poll
-          polarity: 1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - ask
-          - interrogate
-          - interview
-          - question
-          name: question
-          polarity: 1
-          semantic type: event
-      - OntologyNode:
-        examples:
-        - advocate
-        - campaign
-        - convince
-        - encourage
-        - lobbying
-        - persuade
-        - promote
-        name: campaign
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - commit
-        - commitment
-        - pledge
-        - promise
-        name: commitment
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - argue
-        - assert
-        - contend
-        - debate
-        - disagree
-        - discuss
-        - fight
-        name: debate
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - deceive
-        - deception
-        - deceptive
-        - 'false'
-        - misinform
-        name: deception
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - describe
-        - description
-        - discuss
-        - illustrate
-        - outline
-        - report
-        - summarize
-        name: description
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - advocate
-        - approve
-        - endorse
-        - endorsement
-        - espouse
-        - support
-        name: endorsement
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - distinguish
-        - emphasise
-        - emphasize
-        - highlight
-        name: highlighting
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - disclose
-        - inform
-        - report
-        - say
-        - speak
-        - tell
-        name: informing
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - arbitrate
-        - broker
-        - mediate
-        - mediation
-        - referee
-        name: mediation
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - assembly
-        - conference
-        - consult
-        - convene
-        - conversation
-        - dialogue
-        - discuss
-        - forum
-        - meeting
-        - roundtable
-        - seminar
-        - summit
-        - workshop
-        name: meeting
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - bargain
-        - negotiate
-        - negotiation
-        name: negotiation
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - challenge
-        - condemn
-        - criticise
-        - criticize
-        - critique
-        - debunk
-        - denounce
-        - dismiss
-        - dispute
-        - mock
-        - oppose
-        - opposition
-        - question
-        - refute
-        - reject
-        - renounce
-        - subvert
-        name: opposition
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - recommend
-        - recommendation
-        - suggest
-        - suggestion
-        name: suggestion
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - caution
-        - warn
-        - warning
-        name: warning
-        polarity: 1
-        semantic type: event
-    - conflict:
-      - OntologyNode:
-        examples:
-        - abducted
-        - abduction
-        - child abductions
-        - forced recruitment
-        - hostage taking
-        - kidnapped
-        - kidnapping
-        - ransomed
-        name: abduction
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - abuse
-        - harass
-        - neglect
-        - persecute
-        - violate
-        name: abuse
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - assassinate
-        - assassination
-        name: assassination
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - airstrike
-        - ambush
-        - assault
-        - attack
-        - attacked
-        - attacking
-        - attacks
-        - battle
-        - bombard
-        - clash
-        - combat
-        - crossfire
-        - destroyed in combat
-        - fight
-        - genocide
-        - invaded
-        - invasion
-        - massacre
-        - offense
-        - psychological warfare
-        - raiding
-        - shooting
-        - shoots
-        - strike
-        name: attack
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - clan conflict
-        - clan differences
-        - clan tensions
-        name: clan_conflict
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - crackdown
-        - crush
-        - overreact
-        - repress
-        - suppress
-        name: crackdown
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - collapse
-        - coup
-        - defeat
-        - demise
-        - depose
-        - dissolution
-        - exile
-        - oust
-        - overthrow
-        - topple
-        name: defeat
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - ceasefire
-        - disarmament
-        name: disarmament
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - discriminate
-        - exclude
-        - marginalize
-        - profile
-        - segregate
-        - stigmatize
-        name: discriminate
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - draft
-        - enlist
-        - marshal
-        - muster
-        - recruit
-        name: enlist
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        definition: To make use of (sometimes unfairly) to one's own advantage.
-        examples:
-        - cheat
-        - coerce
-        - exploit
-        - intimidate
-        - lure
-        - manipulate
-        name: exploit
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - harass
-        - harassment
-        - persecute
-        - persecution
-        name: harass_or_persecute
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - insurgency
-        - revolt
-        - uprising
-        name: insurgency
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - conflict prevention
-        - conflict resolution
-        - diplomacy
-        - dispute resolution
-        - international covenant
-        - peace building
-        - peace negotiations
-        - peace talks
-        - peacebuilding
-        - peacebuilding activities
-        - peacebuilding efforts
-        - peacebuilding initiatives
-        - peacebuilding processes
-        - peacemaking
-        - stabilization activities
-        - stabilization efforts
-        - statebuilding
-        - treaty
-        name: peacebuilding
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - peacekeepers
-        - peacekeeping
-        name: peacekeeping
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - police brutality
-        name: police_brutality
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - assemble
-        - boycott
-        - civil unrest
-        - clash
-        - crowd
-        - demands
-        - gather
-        - peaceful assembly
-        - picket
-        - protest
-        - rally
-        - riot
-        - social unrest
-        - strikes
-        - turmoil
-        name: protest_or_demonstration
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - accord
-        - accords
-        - agreement
-        - cessation
-        - compromise
-        - conciliation
-        - deal
-        - pact
-        - peace deal
-        - peacebuilding
-        - peacekeeping
-        - pledge
-        - rapprochement
-        - resolution
-        - treaty
-        name: resolution
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - retaliation
-        - retribution
-        - revenge
-        name: retaliation
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - bomb threat
-        - extremism
-        - guerilla
-        - insurgency
-        - political terror
-        - roadside bombing
-        - terrorism
-        - terrorist activity
-        - terrorist acts
-        - terrorist attack
-        - violent extremism
-        name: terrorism
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - intimidate
-        - threat
-        - threaten
-        name: threat
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - excessive force
-        - torture
-        name: torture
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - ethnic conflict
-        - ethnic conflicts
-        - ethnic differences
-        - ethnic divisions
-        - ethnic hatred
-        - ethnic lines
-        - ethnic tensions
-        - ethnic violence
-        - historical conflict
-        - intergroup conflict
-        - tribal conflict
-        name: tribal_conflict
-        polarity: -1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - assault
-        - attack
-        - bombard
-        - civil war
-        - clash
-        - genocide
-        - invaded
-        - military aggression
-        - rebel
-        - war
-        - warfare
-        - warlord
-        name: war
-        polarity: -1
-        semantic type: event
-    - OntologyNode:
-      examples:
-      - build
-      - building
-      - construct
-      - construction
-      - establish
-      name: construction
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - consume
-      - consumption
-      - household consumption
-      - own consumption
-      - use
-      name: consumption
-      polarity: -1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - damage
-      - devastate
-      - ravage
-      name: damage
-      polarity: -1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - conclude
-      - decide
-      - decision
-      name: decision
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - demand
-      - petition
-      - request
-      name: demand
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - deploy
-      - deployment
-      - dispatch
-      name: deployment
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - depreciate
-      - devaluation
-      name: depreciation
-      polarity: -1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - destabilize
-      name: destabilization
-      polarity: -1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - destroy
-      - destruction
-      - ruin
-      name: destruction
-      polarity: -1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - clinical signs
-      - detect
-      - detection
-      - diagnose
-      - diagnostics
-      - signs
-      name: detection
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - broaden
-      - cultivate
-      - develop
-      - development
-      - expand
-      - extend
-      - grow
-      - growth
-      name: development
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - conceal
-      - disguise
-      - evade
-      - hide
-      - mask
-      - shield
-      - stealth
-      name: disguise
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - boost
-      - enhance
-      - enhancement
-      - enrich
-      - enrichment
-      - improve
-      - improvement
-      - supplement
-      - upgrade
-      name: enhancement
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - evacuate
-      - evacuation
-      name: evacuation
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - dispossession
-      - eviction
-      name: eviction
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - discovery
-      - experimentation
-      - exploration
-      - findings
-      - investigation
-      name: exploration
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - compose
-      - derive
-      - extract
-      - isolate
-      - source
-      - synthesize
-      name: extraction
-      polarity: 1
-      semantic type: event
-    - farming:
-      - OntologyNode:
-        examples:
-        - harvest
-        - harvesting
-        - reap
-        name: harvesting
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - grazing
-        - herders
-        - herding
-        - herds
-        name: herding
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        definition: The process of applying controlled amounts of water to plants.
-        examples:
-        - irrigate
-        - irrigating
-        - irrigation
-        name: irrigation
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - cultivate
-        - planting
-        - sow
-        name: planting
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - tilling
-        name: tilling
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - weeding
-        name: weeding
-        polarity: 1
-        semantic type: event
-    - OntologyNode:
-      examples:
-      - aquaculture
-      - fish
-      - fisheries
-      - fishing
-      name: fishing
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - diffuse
-      - diffusion
-      - flow
-      - trickle
-      name: flow
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - forage
-      name: foraging
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - band
-      - categorize
-      - classify
-      - cluster
-      - group
-      - subdivide
-      name: grouping
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - abundance
-      - chick survival
-      - egg productivity
-      - fitness
-      - growth performance
-      - growth rate
-      - hatch
-      - hatching
-      - mortality
-      - reproductive performance
-      - survival
-      - survival rate
-      - survival rates
-      name: hatching
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - hunt
-      - poaching
-      name: hunting
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - arrest
-      - captivity
-      - capture
-      - custody
-      - detain
-      - detention
-      - enslave
-      - imprison
-      - imprisonment
-      - incarcerate
-      name: imprisonment_or_detention
-      polarity: -1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - artificial incubation
-      - brooder
-      - brooders
-      - free range
-      - grower phase
-      - growing period
-      - incubation
-      - incubation period
-      - incubator
-      - incubators
-      - natural incubation
-      - poults
-      - rearing
-      - restocking
-      name: incubation
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - infest
-      - infestation
-      name: infestation
-      pattern:
-      - \b[iI]nfest
-      polarity: -1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - inflation
-      name: inflation
-      polarity: -1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - inhabit
-      - live
-      - occupancy
-      - reside
-      - settle
-      name: inhabiting_or_occupancy
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - consumption
-      - eating
-      - intake
-      name: intake
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - audit
-      - inquiry
-      - investigate
-      - investigation
-      name: investigate
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - FDI
-      - foreign direct investment
-      - fund
-      - invest
-      - investment
-      - spend
-      name: investment
-      polarity: 1
-      semantic type: event
-    - judicial:
-      - OntologyNode:
-        examples:
-        - charge
-        - indict
-        - prosecute
-        name: charge_or_prosecution
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - convict
-        - conviction
-        - fine
-        - jail
-        - penalize
-        - penalty
-        - punish
-        - sentence
-        - sentencing
-        name: conviction_or_sentencing
-        polarity: 1
-        semantic type: event
-    - legislation:
-      - OntologyNode:
-        examples:
-        - control
-        - legislate
-        - mandate
-        - regulate
-        - regulatory framework
-        - repeal
-        - restrict
-        name: regulation
-        pattern:
-        - \b(regulations?|laws?)\b
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - subsidize
-        - subsidy
-        name: subsidization
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - duty
-        - levy
-        - tariff
-        - tax
-        - taxation
-        name: taxation
-        polarity: 1
-        semantic type: event
-    - OntologyNode:
-      examples:
-      - NRM
-      - administrate
-      - command
-      - manage
-      - management
-      - oversee
-      name: management
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - control
-      - exploit
-      - influence
-      - manipulate
-      name: manipulation
-      polarity: 1
-      semantic type: event
-    - medical:
-      - OntologyNode:
-        examples:
-        - contact tracing
-        name: contact_tracing
-        pattern:
-        - (contact tracing)
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - lockdown
-        name: lockdown
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - isolation
-        - quarantine
-        name: quarantine
-        pattern:
-        - (quarantin|shelter[- ]in[- ]place)
-        - \b(restrict\s+movement)
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - cleaning
-        - disinfect
-        - disinfection
-        - sanitization
-        - sanitize
-        name: sanitization
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - curfew
-        - social distancing
-        name: social_distancing
-        pattern:
-        - (social distanc)
-        polarity: 1
-        semantic type: event
-    - OntologyNode:
-      examples:
-      - drilling
-      - fracking
-      - mining
-      name: mining
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      definition: make less severe, serious, or painful; lessen the gravity
-      examples:
-      - alleviate
-      - counteract
-      - curtail
-      - dampen
-      - deter
-      - diffuse
-      - mitigate
-      - mitigation
-      - neutralize
-      - overcome
-      name: mitigation
-      polarity: -1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - change
-      - modify
-      name: modification
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - drive
-      - drove
-      - ignite
-      - initiate
-      - invoke
-      - motivate
-      - prompt
-      - spark
-      - spurred
-      - trigger
-      name: motivation
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - nominate
-      - nomination
-      name: nomination
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - detect
-      - observe
-      - oversee
-      - sense
-      - survey
-      - watch
-      name: observation
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - outbreak
-      - outbreaks
-      - plague
-      - recent outbreaks
-      name: outbreak
-      polarity: -1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - design
-      - plan
-      - strategy
-      name: planning
-      polarity: 1
-      semantic type: event
-    - population:
-      - OntologyNode:
-        examples:
-        - birth
-        name: birth
-        pattern:
-        - birth
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - burial
-        - casualties
-        - casualty
-        - chick mortality
-        - death
-        - deaths
-        - fatalities
-        - fatality
-        - infant mortality
-        - killings
-        - mortality
-        - mortality rate
-        - mortality risks
-        - murder
-        - new deaths
-        - total deaths
-        name: death
-        polarity: 1
-        semantic type: event
-      - migrate:
-        - OntologyNode:
-          examples:
-          - deport
-          - emigrate
-          - emigration
-          - expel
-          name: emigrate
-          polarity: 1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - asylum
-          - immigrate
-          - immigration
-          - invade
-          name: immigrate
-          polarity: 1
-          semantic type: event
-        - OntologyNode:
-          examples:
-          - flee
-          - migrate
-          - migration
-          - relocate
-          name: migrate
-          polarity: 1
-          semantic type: event
-    - OntologyNode:
-      examples:
-      - anticipate
-      - forecast
-      - predict
-      - prediction
-      - project
-      - projection
-      name: prediction
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - organize
-      - plan
-      - prepare
-      name: preparation
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      definition: keep something from happening or arising
-      examples:
-      - limit
-      - prevent
-      - suppress
-      - thwart
-      name: prevention
-      polarity: -1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - cleaning
-      - grading
-      - manufacturing
-      - packing
-      - processing
-      - shipping
-      - sorting
-      - treatment
-      name: processing
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - create
-      - produce
-      - production
-      name: production
-      pattern:
-      - \b([pP]roduction|[yY]ields?)\b
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - ban
-      - criminalize
-      - outlaw
-      - prohibit
-      name: prohibition
-      polarity: -1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - administer
-      - deliver
-      - distribute
-      - give
-      - provide
-      - supply
-      name: provision
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - broadcast
-      - print
-      - publication
-      - publish
-      - release
-      - reprint
-      - write
-      name: publication
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - radicalization
-      name: radicalization
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - react
-      - reaction
-      - respond
-      - response
-      name: reaction_or_response
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - forgiveness
-      - relief
-      name: relief
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      definition: provide a remedy for; redress or make right; restore by reversing
-        or stopping environmental damage
-      examples:
-      - reconcile
-      - remediate
-      - resolve
-      - settle
-      - solve
-      name: remediation
-      polarity: -1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - reconstruct
-      - repair
-      - restore
-      name: repair
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - hens
-      - laying hens
-      - reproduce
-      - reproduction
-      - rooster
-      name: reproduction
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      definition: The collection, organization, and analysis of information to increase
-        understanding of a topic or issue.
-      examples:
-      - experiment
-      - observe
-      - research
-      - science
-      - scientific
-      - study
-      - survey
-      name: research
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - conserve
-      - defend
-      - guard
-      - preserve
-      - protect
-      - safeguard
-      - secure
-      - ward
-      name: securing
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - choose
-      - select
-      - selection
-      name: selection
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - share
-      - sharing
-      name: sharing
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - stabilization
-      - stabilize
-      name: stabilization
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - delay
-      - hamper
-      - limit
-      - shorten
-      - stall
-      - temper
-      name: stalling
-      polarity: -1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - begin
-      - commence
-      - initiate
-      - start
-      name: start
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - continue
-      - exist
-      - remain
-      - stay
-      name: stay_or_remain
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - prop up
-      - shore up
-      - strengthen
-      name: strengthening
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - monitor
-      - surveil
-      name: surveilance
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - count
-      - enumerate
-      - tabulate
-      name: tabulation
-      polarity: 1
-      semantic type: event
-    - trade:
-      - OntologyNode:
-        examples:
-        - export
-        name: export
-        pattern:
-        - \bexports?\b
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - import
-        name: import
-        pattern:
-        - \bimports?\b
-        polarity: 1
-        semantic type: event
-    - training:
-      - OntologyNode:
-        examples:
-        - agriculture training
-        - pest control
-        - post harvest
-        - production practices
-        - weed control
-        name: agriculture_training
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - financial training
-        name: financial_training
-        polarity: 1
-        semantic type: event
-      - humanitarian_training:
-        - OntologyNode:
-          examples:
-          - SPHERE
-          - emergency preparedness training
-          - humanitarian certifications
-          name: emergency_preparedness_training
-          pattern:
-          - (SPHERE)
-          polarity: 1
-          semantic type: event
-      - OntologyNode:
-        examples:
-        - medical training
-        name: medical_training
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - abilities
-        - advice
-        - advisors
-        - caution
-        - centres
-        - certificate
-        - coordinators
-        - course
-        - curricula
-        - direction
-        - educate
-        - exercises
-        - expertise
-        - extension services
-        - guidance
-        - guideline
-        - guides
-        - instructions
-        - leadership
-        - leadership positions
-        - lessons
-        - manpower
-        - manual
-        - manuals
-        - modules
-        - oversight
-        - participants
-        - phases
-        - programme
-        - programs
-        - qualifications
-        - regular basis
-        - skill
-        - skill assessments
-        - skills
-        - staffing
-        - strategic direction
-        - supervision
-        - team members
-        - technical advice
-        - technical assistance
-        - technical capacity
-        - technical expertise
-        - technical knowledge
-        - trainers
-        - training
-        - training activities
-        - training manual
-        - training materials
-        - training programmes
-        - training programs
-        - training session
-        - vocational training
-        name: training
-        polarity: 1
-        semantic type: event
-    - OntologyNode:
-      examples:
-      - buy
-      - food transaction
-      - gift
-      - oil transaction
-      - purchase
-      - repayment
-      - sale
-      - sell
-      - selling
-      - transaction
-      name: transaction
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - modernize
-      - reform
-      - transform
-      name: transformation
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - airborne
-      - community spread
-      - exposure
-      - infectious
-      - spread
-      - transmission
-      name: transmission
-      polarity: -1
-      semantic type: event
-    - transportation:
-      - OntologyNode:
-        examples:
-        - air travel
-        - commercial transportation
-        - public transport
-        name: commercial_transportation
-        polarity: 1
-        semantic type: event
-      - OntologyNode:
-        examples:
-        - commute
-        - personal transportation
-        - taxi
-        name: personal_transportation
-        polarity: 1
-        semantic type: event
-    - OntologyNode:
-      examples:
-      - journey
-      - travel
-      - trip
-      - visit
-      name: travel
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - cast ballot
-      - elect
-      - vote
-      name: voting
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - undermine
-      - weaken
-      name: weakening
-      polarity: -1
-      semantic type: event
-  - property:
-    - OntologyNode:
-      examples:
-      - accountability
-      - responsibility
-      name: accountability
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - affordable
-      - cost-effective
-      - economical
-      - reasonably priced
-      name: affordability
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - aftermath
-      - fallout
-      - following
-      - lingering impact
-      - result
-      - trauma
-      - wake
-      name: aftermath
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - allegiance
-      - loyalty
-      name: allegiance
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - availability
-      name: availability
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - chronic
-      - endemic
-      - longstanding
-      - perennial
-      - persistent
-      - pervasive
-      - prevalence
-      - prevalent
-      - protracted
-      - rampant
-      - recurrent
-      - systemic
-      - widespread
-      name: chronic
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      definition: relating to ordinary citizens and their concerns
-      examples:
-      - citizen
-      - civic
-      - civil
-      name: civic
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - awareness
-      - clarity
-      - common understanding
-      - insight
-      - mutual understanding
-      - public awareness
-      name: common_understanding
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - condition
-      - conditions
-      name: condition
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - absorptive capacity
-      - adaptive capacity
-      - capacities
-      - capacity
-      - coping capacities
-      - coping capacity
-      - coping mechanisms
-      - core capacities
-      - institutional capacity
-      - nets
-      - organizational capacity
-      - response capacities
-      - response capacity
-      - vulnerability
-      name: coping_capacities
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - diversity
-      name: diversity
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - domestic
-      - internal
-      name: domestic
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - antibiotic resistance
-      - antimicrobial resistance
-      - antimicrobials
-      - biodefense
-      - drug resistance
-      - infectivity
-      - microbes
-      - microbial threats
-      - promoters
-      - resistance
-      - resistant pathogens
-      - transporters
-      name: drug_resistance
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - efficiency
-      name: efficiency
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - exotic breeds
-      name: exotic_breeds
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - equality
-      - equity
-      - fairness
-      - integrity
-      name: fairness
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - bilateral
-      - external aid
-      - foreign
-      - foreign aid
-      - multilateral
-      - overseas
-      name: foreign
-      polarity: 1
-      semantic type: property
-    - geographic_resolution:
-      - OntologyNode:
-        examples:
-        - global
-        - world
-        name: global
-        polarity: 1
-        semantic type: property
-      - OntologyNode:
-        examples:
-        - international
-        name: international
-        polarity: 1
-        semantic type: property
-      - OntologyNode:
-        examples:
-        - city
-        - local
-        - town
-        name: local
-        polarity: 1
-        semantic type: property
-      - OntologyNode:
-        examples:
-        - nation
-        - national
-        - state
-        name: national
-        polarity: 1
-        semantic type: entity
-      - OntologyNode:
-        examples:
-        - kebele
-        - provincial
-        - regional
-        - woreda
-        name: sub-national
-        polarity: 1
-        semantic type: property
-    - OntologyNode:
-      examples:
-      - commercial breeds
-      - crossbred
-      - crossbred chickens
-      - crossbreeds
-      - horro
-      - hybrid breeds
-      - hybrids
-      - improved breed
-      - improved breeds
-      - improved chickens
-      - improved genetics
-      - improved horro
-      - improved stock
-      - kuroiler
-      - new breeds
-      name: hybrid_breeds
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - hydroponic
-      name: hydroponic
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - dangerous
-      - insecure
-      - insecurity
-      - unsafe
-      name: insecurity
-      polarity: -1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - instability
-      name: instability
-      polarity: -1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - constitutional
-      - constitutionality
-      - legal
-      - legality
-      name: legality
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - nonutilization
-      name: nonutilization
-      polarity: -1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - peaceful
-      name: peaceful
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - choice
-      - preference
-      - preferences
-      - taste
-      name: preference
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - action
-      - contingency planning
-      - contingency plans
-      - development goals
-      - early action
-      - global strategy
-      - ipc phases
-      - planning
-      - preparedness
-      - preparedness plans
-      - resilience plan
-      - response activities
-      - response measures
-      - response plan
-      - response plans
-      - strategic plan
-      - task force
-      - vulnerability assessment
-      name: preparedness
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - additional costs
-      - capital costs
-      - cost
-      - costs
-      - expenses
-      - hidden costs
-      - high costs
-      - higher costs
-      - indirect costs
-      - input costs
-      - operating costs
-      - opportunity costs
-      - price
-      - recurrent costs
-      - social costs
-      name: price_or_cost
-      pattern:
-      - \b([Cc]osts?|[Pp]rices?)\b
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - private
-      name: private
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - egg productivity
-      - performance
-      - poultry meat productivity
-      - productivity
-      name: productivity
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - public
-      name: public
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - feed quality
-      - quality
-      name: quality
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - resilience
-      - resiliency
-      - robustness
-      name: resilience
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - land rights
-      - land tenure
-      - right to use
-      name: right_to_use
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - risk
-      name: risk
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - cycles
-      - delayed
-      - historical trends
-      - inflation
-      - movements
-      - patterns
-      - recent trends
-      - seasonal
-      - seasonal changes
-      - seasonal patterns
-      - seasonal pressure
-      - seasonal trends
-      - seasonal variation
-      - seasonal variations
-      - seasonality
-      - significant changes
-      - timing
-      - variations
-      name: seasonality
-      polarity: 1
-      semantic type: event
-    - OntologyNode:
-      examples:
-      - safety
-      - security
-      name: security
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - social
-      name: social
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      definition: Being unlikely to move or change.
-      examples:
-      - order
-      - stability
-      name: stability
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - affinity
-      - camaraderie
-      - empathy
-      - goodwill
-      - solidarity
-      - support
-      name: support
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - agricultural surplus
-      - egg surplus
-      - excess
-      - marketable surplus
-      - meat surplus
-      - surplus
-      name: surplus
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - sustainability
-      - sustainable
-      name: sustainable
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - makeshift
-      - temporary
-      name: temporary
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - openness
-      - transparency
-      name: transparency
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - lack
-      - paucity
-      - scant
-      - scarce
-      - shortage
-      - sparse
-      - unavailability
-      name: unavailability
-      polarity: -1
-      semantic type: property
-    - OntologyNode:
-      definition: An epistemic situation involving imperfect or unknown information.
-      examples:
-      - uncertainty
-      - volatility
-      name: uncertainty
-      polarity: -1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - utilization
-      name: utilization
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - precarious
-      - tumult
-      - tumultuous
-      - variability
-      - variable
-      - volatile
-      - volatility
-      name: variability
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - violent
-      name: violent
-      polarity: 1
-      semantic type: property
-    - OntologyNode:
-      examples:
-      - fragile
-      - fragility
-      - tenuous
-      - vulnerability
-      - vulnerable
-      name: vulnerability
-      polarity: 1
-      semantic type: property
+OntologyNode:
+    name: wm
+    children:
+        - OntologyNode:
+            name: concept
+            children:
+                - OntologyNode:
+                    name: agriculture
+                    children:
+                        - OntologyNode:
+                            examples:
+                                - additives
+                                - amounts
+                                - balanced feed
+                                - batches
+                                - broiler feed
+                                - complementary foods
+                                - conversion
+                                - diet
+                                - drug
+                                - enzyme
+                                - feed additives
+                                - feed conversion
+                                - feed formulation
+                                - feed formulations
+                                - feed ingredient
+                                - feed ingredients
+                                - feed material
+                                - feed materials
+                                - feed prices
+                                - feed requirements
+                                - feed supplements
+                                - feeders
+                                - feeding system
+                                - feedlot
+                                - feeds
+                                - feedstuffs
+                                - formula
+                                - formulation
+                                - herbs
+                                - ingredient
+                                - labelling
+                                - labels
+                                - milling
+                                - mixed feed
+                                - parent stocks
+                                - protein source
+                                - rations
+                                - replacement
+                                - supplementation
+                            name: animal_feed
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - agricultural science
+                                - agriculture organization
+                                - animal breeding
+                                - animal health
+                                - animal production
+                                - animal resources
+                                - animal science
+                                - field
+                                - fishery
+                                - genetic improvement
+                                - genetics
+                                - holding
+                                - livestock
+                                - livestock development
+                                - livestock ownership
+                                - livestock research
+                                - livestock revolution
+                                - livestock science
+                                - poultry science
+                                - research
+                                - veterinary medicine
+                                - veterinary microbiology
+                                - veterinary science
+                            name: animal_science
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            name: crop
+                            children:
+                                - OntologyNode:
+                                    definition: A grass cultivated for the edible parts of its grain.
+                                    examples:
+                                        - barley
+                                        - cereals
+                                        - maize
+                                        - sorghum
+                                        - tef
+                                        - wheat
+                                    name: cereals
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - crop land
+                                    name: crop_land
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - cereals
+                                        - crop
+                                        - crop production
+                                        - crop season
+                                        - croplands
+                                        - main cropping
+                                        - main crops
+                                        - major crops
+                                        - paddy
+                                        - paddy rice
+                                        - planting
+                                        - rice crops
+                                        - root
+                                        - season
+                                        - sowing
+                                        - staple
+                                        - staple crops
+                                        - tree crops
+                                    name: crops
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - fodder
+                                    name: fodder
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - maize
+                                        - maize grain
+                                        - maize meal
+                                        - white maize
+                                        - yellow maize
+                                    name: maize
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - major crops
+                                    name: major_crops
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - other crops
+                                    name: other_crops
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - beans
+                                        - lentils
+                                        - peas
+                                        - pulses
+                                    name: pulses
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - red sorghum
+                                        - sorghum
+                                        - sorghum crops
+                                        - white sorghum
+                                    name: sorghum
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - standing crops
+                                    name: standing_crops
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - staple crops
+                                    name: staple_crops
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - tree crops
+                                    name: tree_crops
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - cassava
+                                        - potato
+                                        - sweet potato
+                                        - tubers
+                                    name: tubers
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    definition: vegetable crops and food
+                                    examples:
+                                        - beets
+                                        - cabbage
+                                        - carrots
+                                        - lettuce
+                                        - tomato
+                                        - vegetables
+                                    name: vegetables
+                                    polarity: 1
+                                    semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - cheese
+                                - contract farming
+                                - cows
+                                - dairy
+                                - dairy animals
+                                - dairy cows
+                                - dairy farmers
+                                - dairy farms
+                                - dairy industry
+                                - dairy producers
+                                - dairy sector
+                                - dairy systems
+                                - goat
+                                - larger producers
+                                - milk
+                                - milk production
+                                - processors
+                                - producing
+                                - specialized dairy
+                            name: dairy
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            name: disease
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - blight
+                                        - crop disease
+                                    name: crop_disease
+                                    polarity: -1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - livestock disease
+                                    name: livestock_disease
+                                    polarity: -1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - chicken disease
+                                        - colibacillosis
+                                        - coryza
+                                        - poultry disease
+                                    name: poultry_disease
+                                    polarity: 1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - veterinarian
+                                        - veterinarians
+                                        - veterinary authorities
+                                        - veterinary care
+                                        - veterinary clinics
+                                        - veterinary department
+                                        - veterinary journal
+                                        - veterinary medicine
+                                        - veterinary science
+                                        - veterinary service
+                                        - veterinary services
+                                    name: veterinary_care
+                                    polarity: 1
+                                    semantic type: event
+                        - OntologyNode:
+                            definition: Domesticated animals raised for their labor or to produce commodities such as milk, meat, eggs, fur, leather, or wool.
+                            examples:
+                                - beef
+                                - bull
+                                - calf
+                                - calves
+                                - camel
+                                - cattle
+                                - cow
+                                - dairy cattle
+                                - dairy products
+                                - donkey
+                                - goats
+                                - herds
+                                - horse
+                                - livestock
+                                - milk
+                                - ox
+                                - oxen
+                                - pigs
+                                - sheep
+                            name: livestock_nonpoultry
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            name: pest
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - few swarms
+                                        - fleas
+                                        - flies
+                                        - fly
+                                        - fomites
+                                        - infestations
+                                        - insect
+                                        - insects
+                                        - larvae
+                                        - lice
+                                        - microbes
+                                        - mites
+                                        - mosquito
+                                        - mosquitoes
+                                        - new swarms
+                                        - parasites
+                                        - pests
+                                        - small groups
+                                        - small swarms
+                                        - swarms
+                                        - ticks
+                                        - worms
+                                    name: animal_pests
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - army worm
+                                    name: army_worm
+                                    polarity: -1
+                                    semantic type: event
+                                - OntologyNode:
+                                    name: locust
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - desert locust
+                                            name: desert_locust
+                                            polarity: 1
+                                            semantic type: entity
+                                        - OntologyNode:
+                                            name: gregarious
+                                            children:
+                                                - OntologyNode:
+                                                    patterns:
+                                                        - (hopper\s+band)|(bands?\s+of\s+hoppers)
+                                                    examples:
+                                                        - bands of hoppers
+                                                        - immature
+                                                        - locust hopper groups
+                                                    name: hopper_band
+                                                    polarity: -1
+                                                    semantic type: event
+                                                - OntologyNode:
+                                                    patterns:
+                                                        - (locust\s+swarm)|(swarms?\s+of\s+locust)
+                                                        - \bDL\b
+                                                        - locust
+                                                    examples:
+                                                        - adult
+                                                        - locust infestation
+                                                        - locust swarm
+                                                        - mature maturation
+                                                        - swarm
+                                                    name: locust_swarm
+                                                    polarity: -1
+                                                    semantic type: event
+                                        - OntologyNode:
+                                            examples:
+                                                - locust eggs
+                                            name: locust_eggs
+                                            polarity: -1
+                                            semantic type: event
+                                        - OntologyNode:
+                                            name: solitary
+                                            children:
+                                                - OntologyNode:
+                                                    examples:
+                                                        - hopper
+                                                        - immature
+                                                        - instar
+                                                        - solitarious hopper
+                                                        - solitary
+                                                    name: solitary_hopper
+                                                    polarity: -1
+                                                    semantic type: event
+                                                - OntologyNode:
+                                                    examples:
+                                                        - mature
+                                                        - solitarious adult locust
+                                                        - solitary locust
+                                                    name: solitary_locust
+                                                    polarity: -1
+                                                    semantic type: event
+                        - OntologyNode:
+                            name: poultry
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - ancestors
+                                        - backyard
+                                        - backyard farms
+                                        - backyard flocks
+                                        - backyard producers
+                                        - backyard system
+                                        - backyard systems
+                                        - backyards
+                                        - commercial systems
+                                        - coops
+                                        - follower farmers
+                                        - gardens
+                                        - homesteads
+                                        - peasant
+                                        - rearing activities
+                                        - rural producers
+                                        - small flocks
+                                        - smallholder
+                                        - traditional backyard
+                                        - traditional chickens
+                                        - traditional methods
+                                        - traditional practices
+                                        - traditional system
+                                        - traditional systems
+                                        - yard
+                                    name: backyard_poultry_farming
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - healthy birds
+                                        - live birds
+                                        - new birds
+                                        - vaccinated birds
+                                    name: bird_condition_healthy
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - affected birds
+                                        - avian pathology
+                                        - bats
+                                        - carrier
+                                        - carriers
+                                        - culled birds
+                                        - dead birds
+                                        - dead chickens
+                                        - diseased birds
+                                        - healthy birds
+                                        - hosts
+                                        - infected birds
+                                        - infected farms
+                                        - infected msc
+                                        - live birds
+                                        - new birds
+                                        - old chicks
+                                        - sick animals
+                                        - sick birds
+                                        - sick chickens
+                                    name: bird_condition_sick
+                                    polarity: -1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - broiler
+                                        - broiler chickens
+                                        - broilers
+                                        - commercial breeds
+                                        - commercial chickens
+                                        - commercial lines
+                                        - kuroiler
+                                        - meat chickens
+                                    name: broiler_chickens
+                                    polarity: 1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - cock
+                                        - cockerel
+                                        - cockerels
+                                        - cocks
+                                        - male chicken
+                                        - rooster
+                                        - stud
+                                    name: cockerel
+                                    polarity: 1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - DOC
+                                        - babies
+                                        - baby chicks
+                                        - broiler chicks
+                                        - chick
+                                        - chick mortality
+                                        - chicks
+                                        - day old chicks
+                                        - embryo
+                                        - hatcheries
+                                        - nests
+                                        - offspring
+                                    name: day_old_chicks
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - clutch
+                                        - egg clutch
+                                        - egg number
+                                        - egg offtake
+                                        - egg size
+                                        - egg weight
+                                        - eggs
+                                        - embryo
+                                        - hatchability
+                                        - high egg
+                                        - shell
+                                        - shell thickness
+                                        - total egg
+                                        - yolk
+                                    name: egg
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - backyard flocks
+                                        - base situation
+                                        - bird flocks
+                                        - bird market
+                                        - commercial flocks
+                                        - flock
+                                        - flock size
+                                        - flock sizes
+                                        - flock structure
+                                        - flocks
+                                        - larger flocks
+                                        - plumage colour
+                                        - restocking
+                                        - small flock
+                                        - small flocks
+                                        - whole flock
+                                    name: flock_size
+                                    polarity: 1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - domestic ducks
+                                        - domestic fowl
+                                        - duck
+                                        - duck raising
+                                        - ducklings
+                                        - ducks
+                                        - fowl
+                                        - fowl pox
+                                        - fowls
+                                        - geese
+                                        - goose
+                                        - muscovy ducks
+                                        - ostriches
+                                        - other species
+                                        - pheasants
+                                        - pigeon
+                                        - quail
+                                        - quails
+                                        - swan
+                                        - waterfowl
+                                        - wild bird
+                                    name: fowl
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - backyard chickens
+                                        - backyard flocks
+                                        - breeds
+                                        - crosses
+                                        - domestic chickens
+                                        - improved indigenous
+                                        - indigenous animals
+                                        - indigenous breeds
+                                        - indigenous chickens
+                                        - indigenous hens
+                                        - indigenous populations
+                                        - local breeds
+                                        - mixed systems
+                                        - native breeds
+                                        - native chickens
+                                        - races
+                                        - scavenging chickens
+                                        - traditional breeds
+                                        - traditional chickens
+                                    name: indigenous_breeds
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - brooder
+                                        - brooders
+                                        - broody hen
+                                        - broody hens
+                                        - commercial layers
+                                        - female chicken
+                                        - hatchery
+                                        - hen
+                                        - hens
+                                        - indigenous hens
+                                        - laying hens
+                                        - mother
+                                        - mother hen
+                                        - mothers
+                                        - rearers
+                                        - spent hens
+                                    name: laying_hens
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - chicken
+                                        - egg
+                                        - poultry
+                                    name: poultry
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - commercial farms
+                                        - commercial producers
+                                        - egg traders
+                                        - feed industry
+                                        - feed sector
+                                        - hatcheries
+                                        - livestock sector
+                                        - poultry farmers
+                                        - poultry feed
+                                        - poultry industry
+                                        - poultry meat
+                                        - poultry producers
+                                        - poultry production
+                                        - poultry products
+                                        - poultry sci
+                                        - poultry science
+                                        - poultry sector
+                                        - slaughterhouses
+                                        - veterinary department
+                                    name: poultry_sector
+                                    polarity: 1
+                                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - civil liberties
+                    name: civil_liberties
+                    polarity: 1
+                    semantic type: entity
+                - OntologyNode:
+                    examples:
+                        - civil society
+                    name: civil_society
+                    polarity: 1
+                    semantic type: entity
+                - OntologyNode:
+                    name: crisis_or_disaster
+                    children:
+                        - OntologyNode:
+                            name: conflict
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - acts
+                                        - armed
+                                        - armed conflict
+                                        - armed conflicts
+                                        - civil conflicts
+                                        - civil wars
+                                        - combatants
+                                        - conflict
+                                        - conflict resolution
+                                        - crime
+                                        - disorder
+                                        - drug
+                                        - fighting
+                                        - foreign fighters
+                                        - havoc
+                                        - hostilities
+                                        - intra
+                                        - jihadism
+                                        - killing
+                                        - proliferation
+                                        - terrorists
+                                        - threats
+                                        - violent conflict
+                                        - wars
+                                    name: armed_conflict
+                                    polarity: 1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - abduction
+                                        - assault
+                                        - blackmail
+                                        - bribery
+                                        - burglary
+                                        - corruption
+                                        - crime
+                                        - crimes
+                                        - criminal
+                                        - cybercrimes
+                                        - domestic violence
+                                        - embezzlement
+                                        - exploitation
+                                        - extortion
+                                        - harassment
+                                        - homicide
+                                        - illegal
+                                        - illegal activities
+                                        - illicit activities
+                                        - kidnap
+                                        - kidnapping
+                                        - laundering
+                                        - lawlessness
+                                        - looted
+                                        - looting
+                                        - murdered
+                                        - racketeering
+                                        - rape
+                                        - riots
+                                        - robbery
+                                        - sexual abuse
+                                        - sexual exploitation
+                                        - smuggling
+                                        - steal
+                                        - stealing
+                                        - stolen
+                                        - terrorism
+                                        - theft
+                                        - torture
+                                        - trafficing
+                                        - trafficking
+                                        - vandalism
+                                        - violations
+                                        - violent crime
+                                    name: crime
+                                    polarity: -1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - alienation
+                                        - anger
+                                        - backlash
+                                        - contention
+                                        - controversy
+                                        - criticism
+                                        - discontent
+                                        - dissatisfaction
+                                        - dissent
+                                        - distrust
+                                        - friction
+                                        - frustration
+                                        - frustrations
+                                        - grievance
+                                        - protest
+                                        - rejection
+                                        - resentment
+                                        - sentiments
+                                        - unrest
+                                    name: discontent
+                                    polarity: -1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - armed clash
+                                        - armed groups
+                                        - armed mobilization
+                                        - army mobilization
+                                        - clash
+                                        - clashes
+                                        - conflict
+                                        - feud
+                                        - fighting
+                                        - genocide
+                                        - hostility
+                                        - infighting
+                                        - insurgency
+                                        - oppression
+                                        - oppressive regime
+                                        - raid
+                                        - regional turmoil
+                                        - sabotage
+                                        - skirmish
+                                        - tyranny
+                                        - vandalized
+                                        - violence
+                                        - violence in the region
+                                        - war
+                                    name: hostility
+                                    polarity: -1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - adversity
+                                        - burden
+                                        - challenge
+                                        - distress
+                                        - faction
+                                        - feud
+                                        - frustration
+                                        - hardship
+                                        - mistrust
+                                        - polarization
+                                        - political instability
+                                        - political tension
+                                        - political tensions
+                                        - resentment
+                                        - rivalry
+                                        - stalemate
+                                        - stress
+                                        - threatening
+                                    name: tension
+                                    polarity: -1
+                                    semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - alarm
+                                - alerts
+                                - early action
+                                - early warning
+                                - emergency preparedness
+                                - false alarm
+                                - fews net
+                                - fewsnet
+                                - forecasting
+                                - giews
+                                - risk reduction
+                                - safety
+                                - warning
+                            name: early_warning
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            name: environmental
+                            children:
+                                - OntologyNode:
+                                    definition: A prolonged shortage in the water supply.
+                                    examples:
+                                        - drought
+                                        - droughts
+                                        - low rainfall
+                                    name: drought
+                                    polarity: -1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - aftershock
+                                        - earthquake
+                                        - earthquakes
+                                        - tremor
+                                        - tremors
+                                    name: earthquake
+                                    polarity: -1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - acidification
+                                        - deltas
+                                        - desertification
+                                        - environmental degradation
+                                        - environmental stress
+                                        - erosion
+                                        - evaporation
+                                        - extraction
+                                        - inundation
+                                        - overexploitation
+                                        - salinity
+                                        - salinization
+                                        - sedimentation
+                                    name: environmental_degradation
+                                    polarity: -1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - flash flood
+                                        - flood
+                                        - flooding
+                                        - storm surge
+                                        - tsunami
+                                    name: flood
+                                    polarity: -1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - cyclones
+                                        - episodes
+                                        - event
+                                        - extremes
+                                        - hail
+                                        - heavy
+                                        - landslides
+                                        - monsoon
+                                        - natural disaster
+                                        - natural disasters
+                                        - rain
+                                        - strong winds
+                                        - tropical cyclones
+                                        - tsunamis
+                                        - typhoon
+                                        - typhoons
+                                        - weather
+                                        - winds
+                                    name: natural_disaster
+                                    polarity: -1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - cyclone
+                                        - hurricane
+                                        - landfall
+                                        - storm
+                                    name: storm
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - volcanic eruption
+                                        - volcano
+                                    name: volcanic_eruption
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - wild fire
+                                        - wildfire
+                                    name: wildfire
+                                    polarity: -1
+                                    semantic type: event
+                        - OntologyNode:
+                            definition: The rapid spread of disease to a large population in a short amount of time.
+                            examples:
+                                - disease
+                                - epidemic
+                                - global pandemic
+                                - pandemic
+                            name: epidemic
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - famine
+                                - hunger
+                                - starvation
+                            name: famine
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - depression
+                                - economic crisis
+                                - financial crisis
+                                - recession
+                            name: recession
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - adverse shocks
+                                - catastrophe
+                                - catastrophic events
+                                - climate shocks
+                                - climatic shocks
+                                - disturbances
+                                - external shocks
+                                - extreme events
+                                - multiple shocks
+                                - other shocks
+                                - shocks
+                                - worse outcomes
+                            name: shocks
+                            polarity: 1
+                            semantic type: event
+                - OntologyNode:
+                    examples:
+                        - beliefs
+                        - cultural norms
+                        - social norms
+                        - traditions
+                    name: cultural_norms
+                    polarity: 1
+                    semantic type: entity
+                - OntologyNode:
+                    examples:
+                        - curfew
+                    name: curfew
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - discrimination
+                        - exclusion
+                        - racism
+                        - stratification
+                    name: discrimination
+                    polarity: -1
+                    semantic type: event
+                - OntologyNode:
+                    name: economy
+                    children:
+                        - OntologyNode:
+                            examples:
+                                - assets
+                                - holdings
+                                - land ownership
+                                - land property assets
+                                - parcels
+                                - property
+                                - wealth
+                            name: assets
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - budget
+                            name: budget
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - GDP
+                                - GNP
+                                - administrations
+                                - banks
+                                - counterparts
+                                - customs
+                                - domestic market
+                                - domestic markets
+                                - downstream markets
+                                - employment
+                                - formal markets
+                                - holders
+                                - main market
+                                - main markets
+                                - major markets
+                                - many markets
+                                - market disruptions
+                                - market sheds
+                                - market sites
+                                - market supplies
+                                - markets
+                                - monitored markets
+                                - most markets
+                                - open markets
+                                - other markets
+                                - several markets
+                                - stock market
+                                - urban markets
+                            name: commerce
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - business
+                                - commercial enterprise
+                                - company
+                                - corporation
+                            name: commercial_enterprise
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - commercial farm
+                                - commercial farming
+                                - commercial operations
+                                - commercial producers
+                                - contract farmers
+                                - contract growers
+                                - enterprises
+                                - feedlot
+                                - large farmers
+                                - large farms
+                                - large producers
+                                - larger producers
+                                - medium enterprises
+                                - orchard
+                                - outgrowers
+                                - plantation
+                                - ranch
+                            name: commercial_farmers
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - competition
+                            name: competition
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - cash
+                                - currency
+                                - dollar
+                                - money
+                                - usd
+                            name: currency
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - debt
+                                - deficit
+                                - loan
+                            name: debt
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - comparative advantages
+                                - economic benefits
+                                - economic consequences
+                                - economic costs
+                                - economic damage
+                                - economic effects
+                                - economic empowerment
+                                - economic factors
+                                - economic feasibility
+                                - economic gains
+                                - economic impact
+                                - economic impacts
+                                - economic implications
+                                - economic importance
+                                - economic incentives
+                                - economic opportunities
+                                - economic reasons
+                                - economic shocks
+                                - economic situation
+                                - economic system
+                                - economists
+                                - economy
+                                - elasticity
+                                - monetary impact
+                                - moral hazard
+                                - outcomes
+                                - potential benefits
+                                - social benefits
+                                - social value
+                            name: economy
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - card
+                                - consumer prices
+                                - currencies
+                                - default
+                                - disbursements
+                                - discount rate
+                                - dollar
+                                - exchange
+                                - exchange rate
+                                - interest rate
+                                - interest rates
+                                - premiums
+                                - ratings
+                                - reserve
+                                - stocking rates
+                                - vat
+                            name: exchange_rate
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - charge
+                                - expense
+                                - fee
+                                - payment
+                                - rent
+                            name: expense
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - assets
+                                - award
+                                - banking
+                                - banks
+                                - borrowing
+                                - capital
+                                - card
+                                - cards
+                                - cash
+                                - collateral
+                                - cover
+                                - credit
+                                - creditors
+                                - debt
+                                - donation
+                                - endowment
+                                - finance
+                                - financial
+                                - financial capacity
+                                - financial capital
+                                - financial institutions
+                                - financial markets
+                                - financial resources
+                                - financial sector
+                                - financial services
+                                - financial support
+                                - fiscal space
+                                - funding
+                                - grant
+                                - invest
+                                - investment
+                                - lenders
+                                - lending
+                                - liquidity
+                                - loan
+                                - microfinance
+                                - natural capital
+                                - physical capital
+                                - social capital
+                                - working capital
+                            name: finance
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - compensation
+                                - earnings
+                                - household
+                                - income
+                                - paycheck
+                                - revenue
+                                - royalties
+                                - salary
+                                - wages
+                            name: income
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - casual labour
+                                - decent work
+                                - good job
+                                - hard work
+                                - hired labour
+                                - job activities
+                                - labor
+                                - labour
+                                - labour force
+                                - labour market
+                                - wage
+                                - work
+                                - workload
+                                - workplace
+                            name: labor
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - employment
+                                - job
+                                - livelihood
+                            name: livelihood
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - boxes
+                                - brands
+                                - butchers
+                                - collectors
+                                - cooperatives
+                                - crates
+                                - dealers
+                                - distributors
+                                - exporters
+                                - growers
+                                - importers
+                                - larger producers
+                                - marketers
+                                - outlets
+                                - packaging
+                                - processing
+                                - processors
+                                - producers
+                                - restaurants
+                                - retailers
+                                - sales
+                                - sellers
+                                - supermarkets
+                                - suppliers
+                                - traders
+                                - transporters
+                                - vendors
+                                - wholesalers
+                            name: marketing
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - bazaar
+                                - grocer
+                                - grocery
+                                - grocery storage
+                                - marketplace
+                                - physical market
+                                - produce market
+                                - retailer
+                                - retailers
+                                - shop
+                                - shopping
+                                - stall
+                                - store
+                                - supermarket
+                                - vendor
+                                - wet market
+                            name: marketplace
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - disbursement
+                                - drawdown
+                                - payment
+                                - payout
+                                - remittance
+                                - stipend
+                            name: payment
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - purchasing power
+                            name: purchasing_power
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - entrepreneurs
+                                - entrepreneurship
+                                - small businesses
+                            name: small_businesses
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - farmers
+                                - fields
+                                - fp farmers
+                                - holders
+                                - individual farmers
+                                - men farmers
+                                - pastoralists
+                                - peasant
+                                - poor farmers
+                                - producing households
+                                - rural farmers
+                                - rural producers
+                                - small farmers
+                                - small farms
+                                - small holders
+                                - small producers
+                                - smallholder
+                                - smallholder farmers
+                                - smallholders
+                                - smallscale
+                                - subsistence farmers
+                                - traditional sector
+                                - villagers
+                            name: small_farmers
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - duties
+                                - revenue
+                                - subsidies
+                                - subsidy
+                                - tariff
+                                - tax
+                                - taxes
+                            name: taxes
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - unemployment
+                            name: unemployment
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - labor
+                                - professionals
+                                - staff
+                                - worker
+                                - workforce
+                            name: workforce
+                            polarity: 1
+                            semantic type: event
+                - OntologyNode:
+                    examples:
+                        - courses
+                        - curriculum
+                        - education
+                        - instruction
+                        - lessons
+                        - literacy
+                        - mentorship
+                        - schooling
+                        - trainings
+                        - tutoring
+                    name: education
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    name: entity
+                    children:
+                        - OntologyNode:
+                            examples:
+                                - african countries
+                                - african governments
+                                - african leaders
+                                - african nations
+                                - african societies
+                                - african states
+                            name: african_governments
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - Harakat al-Shabaab al-Mujahideen
+                                - Mujahideen Youth Movement
+                                - al shabaab
+                                - al-shabaab
+                                - al-shabab
+                                - hsm
+                            name: al-shabaab
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - animal
+                                - animal resources
+                                - animals
+                                - bats
+                                - beast
+                                - buffalo
+                                - buffaloes
+                                - bulls
+                                - bush
+                                - camel
+                                - camels
+                                - creature
+                                - critter
+                                - dead animals
+                                - dogs
+                                - domestic animals
+                                - donkeys
+                                - goats
+                                - horses
+                                - indigenous animals
+                                - individual animals
+                                - infected animals
+                                - lamb
+                                - large animals
+                                - larger animals
+                                - long distances
+                                - mammals
+                                - mice
+                                - mules
+                                - other animals
+                                - pets
+                                - piglets
+                                - pork
+                                - rats
+                                - rodents
+                                - sick animals
+                                - small animals
+                                - turkeys
+                                - wild animals
+                                - wildlife
+                                - young animals
+                            name: animal
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - artifact
+                            name: artifact
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - border
+                                - land border
+                            name: border
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - drone
+                                - drones
+                                - uas
+                                - uav
+                                - unmanned aerial vehicle
+                                - unmanned air system
+                                - unmanned air vehicle
+                            name: drone
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - chirps
+                                - climate information
+                                - crop monitor
+                                - data
+                                - field
+                                - field reports
+                                - ground
+                                - ground observations
+                                - inputs
+                                - observations
+                                - regional experts
+                                - reports
+                                - satellite
+                                - weather data
+                            name: field_reports
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - gang
+                                - gangs
+                            name: gangs
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - GPE
+                                - city
+                                - nation
+                            name: geo-political_entity
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - administration
+                                - administrations
+                                - agency
+                                - association
+                                - authority
+                                - bureau
+                                - center
+                                - commission
+                                - council
+                                - departments
+                                - directorate
+                                - government entity
+                                - governorate
+                                - implementing agencies
+                                - institute
+                                - institutes
+                                - institution
+                                - line ministries
+                                - ministry
+                                - office
+                                - offices
+                                - organisation
+                                - prefecturates
+                            name: government_entity
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - hamas
+                            name: hamas
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - agencies
+                                - aid
+                                - aid workers
+                                - behalf
+                                - dod
+                                - emergency assistance
+                                - external assistance
+                                - force
+                                - foreign aid
+                                - form
+                                - humanitarian
+                                - humanitarian action
+                                - humanitarian actors
+                                - humanitarian agencies
+                                - humanitarian assistance
+                                - humanitarian needs
+                                - humanitarian operations
+                                - humanitarian organizations
+                                - humanitarian partners
+                                - humanitarian response
+                                - humanitarian situation
+                                - humanitarian workers
+                                - humanitarians
+                                - katrina
+                                - mission
+                                - missions
+                                - ngos
+                                - receiving
+                                - relief
+                                - teams
+                                - unicef
+                                - unsom
+                                - unsom officer
+                            name: humanitarian_actors
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - indigenous communities
+                                - indigenous people
+                            name: indigenous_communities
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - global community
+                                - international agencies
+                                - international institutions
+                                - international ngos
+                                - international organizations
+                                - ngo
+                                - ngos
+                            name: international_organizations
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - isil
+                                - isis
+                            name: isil
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            name: locations
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - big cities
+                                        - capitals
+                                        - cities
+                                        - city
+                                        - major cities
+                                        - newspapers
+                                        - secondary cities
+                                        - urban areas
+                                        - urban centers
+                                        - urban centre
+                                        - urban markets
+                                    name: city
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - city
+                                        - country
+                                        - geo-location
+                                        - location
+                                    name: location
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - neighboring country
+                                    name: neighboring_country
+                                    polarity: 1
+                                    semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - lord's resistance army
+                                - lord's resistance movement
+                                - lra
+                            name: lord's_resistance_army
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - military exercise
+                                - military game
+                                - military maneuvers
+                            name: military_exercise
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - military
+                                - military force
+                                - military power
+                            name: military_power
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - bilateral donors
+                                - development actors
+                                - embassies
+                                - external assistance
+                                - implementing partners
+                                - multilateral contributions
+                                - multilateral organisations
+                                - multilateral system
+                                - other partners
+                                - sector partners
+                                - societies
+                                - trading partners
+                                - union
+                            name: multilateral_system
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - islam
+                                - mosque
+                                - muslim communities
+                                - muslim world
+                                - muslims
+                            name: muslim_communities
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - external actors
+                                - external intervention
+                                - nonstate actors
+                                - other stakeholders
+                            name: nonstate_actors
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - opposition
+                                - opposition groups
+                                - opposition leaders
+                                - opposition parties
+                                - opposition party
+                                - opposition strongholds
+                                - opposition supporters
+                                - political adversary
+                                - political opponents
+                                - political rival
+                            name: opposition_party
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - NGO
+                                - community based organization
+                                - community group
+                                - cooperative
+                                - organization
+                            name: organization
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            name: people
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - academic
+                                        - analyst
+                                        - classmate
+                                        - expert
+                                        - faculty
+                                        - freshman
+                                        - intellectual
+                                        - professor
+                                        - pupil
+                                        - researcher
+                                        - scholar
+                                        - schoolchildren
+                                        - scientist
+                                        - sophomore
+                                        - specialist
+                                        - student
+                                    name: academic
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - activist
+                                        - crowd
+                                        - demonstrator
+                                        - protester
+                                    name: activist
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - adult
+                                        - elder
+                                        - elderly
+                                        - men
+                                        - senior citizen
+                                        - women
+                                    name: adults
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - adviser
+                                        - advisor
+                                        - analysts
+                                        - confidant
+                                        - consultant
+                                        - consultants
+                                        - expert
+                                        - experts
+                                        - operators
+                                        - practitioners
+                                        - promoters
+                                        - scientists
+                                        - specialists
+                                        - technicians
+                                        - trainers
+                                        - volunteers
+                                    name: adviser
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - adolescent
+                                        - child
+                                        - children
+                                        - juvenile
+                                        - minor
+                                        - teenage
+                                        - teenager
+                                        - young people
+                                        - youth
+                                    name: child_or_youth
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - citizen
+                                    name: citizen
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - cartel
+                                        - criminal
+                                        - mafia
+                                        - mafioso
+                                        - pirate
+                                        - smuggler
+                                        - syndicate
+                                        - warlord
+                                    name: criminal
+                                    polarity: -1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - captive
+                                        - detainee
+                                        - hostage
+                                        - inmate
+                                        - prisoner
+                                        - slave
+                                    name: detainee
+                                    polarity: -1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - aristocracy
+                                        - aristocrat
+                                        - elite
+                                        - king
+                                        - lord
+                                        - monarch
+                                        - queen
+                                    name: elites
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - VEO
+                                        - crusader
+                                        - islamist
+                                        - jihadist
+                                        - militant
+                                        - separatist
+                                        - supremacist
+                                        - terrorist
+                                        - vigilante
+                                        - violent extremist organization
+                                    name: extremist
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - cowherd
+                                        - farm worker
+                                        - farmer
+                                        - farmhand
+                                        - goatherd
+                                        - grazier
+                                        - pastoralist
+                                        - rancher
+                                        - sharecropper
+                                        - shepherd
+                                        - smallholder
+                                        - stockmen
+                                    name: farm_worker
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - ambassador
+                                        - attorney general
+                                        - bureaucrat
+                                        - congressman
+                                        - congressperson
+                                        - congresswoman
+                                        - consul
+                                        - diplomat
+                                        - elected official
+                                        - envoy
+                                        - government worker
+                                        - minister
+                                        - politician
+                                        - president
+                                        - public official
+                                        - senator
+                                    name: government_worker
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - CHW
+                                        - community health worker
+                                        - doctor
+                                        - first responders
+                                        - medic
+                                        - nurse
+                                        - nursing
+                                        - physicians assistant
+                                    name: health_worker
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    patterns:
+                                        - household
+                                    examples:
+                                        - clans
+                                        - displaced households
+                                        - families
+                                        - family
+                                        - family compound
+                                        - household
+                                        - individual households
+                                        - large households
+                                        - many families
+                                        - many households
+                                        - most households
+                                        - poorest households
+                                        - producing households
+                                        - wealthier households
+                                    name: household
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - baby
+                                        - infant
+                                        - newborn
+                                    name: infant
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - landholder
+                                        - landlord
+                                        - landowner
+                                    name: landowner
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - law enforcement
+                                        - local officials
+                                        - local police
+                                        - police
+                                        - police forces
+                                        - police officer
+                                        - security officials
+                                    name: law_enforcement_officials
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - maternal
+                                        - mother
+                                        - mothers
+                                    name: maternal
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - husband
+                                        - man
+                                        - men
+                                    name: men
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    name: migration
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - IDP
+                                                - displaced person
+                                                - returnee
+                                            name: displaced_person
+                                            polarity: 1
+                                            semantic type: entity
+                                        - OntologyNode:
+                                            examples:
+                                                - economic migrant
+                                                - migrant
+                                            name: migrant
+                                            polarity: -1
+                                            semantic type: entity
+                                        - OntologyNode:
+                                            examples:
+                                                - asylum seeker
+                                                - refugee
+                                                - returnee
+                                            name: refugee
+                                            polarity: 1
+                                            semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - admiral
+                                        - armed forces
+                                        - armies
+                                        - army
+                                        - battalion
+                                        - colonel
+                                        - commander
+                                        - general
+                                        - lieutenant
+                                        - militants
+                                        - military
+                                        - officer
+                                        - regiment
+                                        - soldier
+                                        - troops
+                                    name: military_personnel
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - militia
+                                    name: militia
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - anchor
+                                        - blogger
+                                        - broadcaster
+                                        - correspondent
+                                        - journalist
+                                        - news anchor
+                                        - newsmedia
+                                        - reporter
+                                    name: newsmedia
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - observer
+                                        - watchdog
+                                    name: observer
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - community
+                                        - group
+                                        - person or group
+                                        - society
+                                        - village
+                                    name: person_or_group
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - insurgents
+                                        - militant group
+                                        - rebel group
+                                    name: rebels
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - task force
+                                        - taskforce
+                                    name: taskforce
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - voter
+                                    name: voter
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - bride
+                                        - female farmers
+                                        - females
+                                        - girls
+                                        - mothers
+                                        - wife
+                                        - wives
+                                        - woman
+                                        - women
+                                        - women farmers
+                                    name: women
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - young adults
+                                        - young men
+                                        - young women
+                                    name: young_adults
+                                    polarity: 1
+                                    semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - church
+                                - congregation
+                                - parish
+                                - seminary
+                            name: religious_entity
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            definition: 'note: in Kenya, the ruling party is the Jubilee party'
+                            examples:
+                                - incumbent
+                                - incumbent government
+                                - jubilee party
+                                - ruling coalition
+                                - ruling party
+                            name: ruling_party
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - communes
+                                - farmlands
+                                - rural
+                                - rural areas
+                                - rural communities
+                                - rural development
+                                - rural economies
+                                - rural households
+                                - rural incomes
+                                - rural livelihoods
+                                - rural markets
+                                - rural populations
+                                - rural producers
+                                - rural regions
+                                - rural roads
+                                - rural sector
+                                - rural villages
+                                - subsistence
+                            name: rural_households
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - cities
+                                - city
+                                - city center
+                                - rural settings
+                                - slums
+                                - urban
+                                - urban areas
+                                - urban centers
+                                - urban communities
+                                - urban households
+                                - urban markets
+                                - urban populations
+                                - urban residents
+                                - urban settings
+                            name: urban_households
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - SUV
+                                - aeroplane
+                                - airplane
+                                - ambulance
+                                - automobile
+                                - bicycle
+                                - bike
+                                - boat
+                                - bus
+                                - car
+                                - helicopter
+                                - motorcycle
+                                - tractor
+                                - train
+                                - truck
+                                - van
+                                - vehicle
+                            name: vehicle
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - ammunition
+                                - explosives
+                                - firearms
+                                - guns
+                                - light weapons
+                                - small arms
+                                - weapons
+                            name: weapons
+                            polarity: 1
+                            semantic type: entity
+                - OntologyNode:
+                    name: environment
+                    children:
+                        - OntologyNode:
+                            examples:
+                                - climate
+                            name: climate
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - changing climate
+                                - climate
+                                - climate action
+                                - climate change
+                                - climate extremes
+                                - climate impacts
+                                - climate migration
+                                - climate models
+                                - climate resilience
+                                - climate risks
+                                - climate science
+                                - climate security
+                                - climate shocks
+                                - climate variability
+                                - climatic change
+                                - deforestation
+                                - emissions scenarios
+                                - environmental change
+                                - ghg
+                                - global change
+                                - global warming
+                                - human activity
+                                - human factors
+                                - natural systems
+                            name: climate_change
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - biodiversity
+                                - ecology
+                                - ecosystem
+                                - habitat
+                                - riparian
+                                - wildlife
+                            name: ecology
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - aerosol
+                                - aerosols
+                                - air
+                                - anthropogenic emissions
+                                - atmosphere
+                                - emission factors
+                                - emission reductions
+                                - evapotranspiration
+                                - heatwave
+                                - lungs
+                                - ozone
+                                - radiation
+                                - solar radiation
+                                - surface air
+                                - thermocline
+                                - thermotolerance
+                                - tropospheric ozone
+                            name: emissions
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - environmental impacts
+                            name: environmental_impacts
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - afforestation
+                                - agroforestry
+                                - biodiversity
+                                - deforestation
+                                - forest
+                                - forest area
+                                - forest cover
+                                - forest degradation
+                                - forest products
+                                - forest resources
+                                - forestry
+                                - forests
+                                - logging
+                                - mangroves
+                                - protected areas
+                                - reforestation
+                                - terrestrial ecosystems
+                                - timber
+                                - tree
+                                - vegetation
+                            name: forestry
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - climate changes
+                                - degrees
+                                - drier
+                                - extreme heat
+                                - extreme temperatures
+                                - heat
+                                - heat stress
+                                - heat waves
+                                - high temperatures
+                                - higher temperatures
+                                - rising temperatures
+                                - temperature increases
+                                - temperatures
+                                - warmer temperatures
+                            name: higher_temperatures
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            name: meteorology
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - precipitation
+                                        - rain
+                                        - rainfall
+                                        - storm
+                                    name: precipitation
+                                    polarity: 1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - temperature
+                                    name: temperature
+                                    polarity: 1
+                                    semantic type: event
+                                - OntologyNode:
+                                    definition: The state of the atmosphere, describing the degree to which it is hot or cold, wet or dry, calm or stormy, clear or cloudy.
+                                    examples:
+                                        - climate variability
+                                        - extreme winds
+                                        - humid
+                                        - rainfall
+                                        - rains
+                                        - snow
+                                        - storm
+                                        - weather
+                                        - weather systems
+                                        - wet
+                                        - wetter
+                                    name: weather
+                                    polarity: 1
+                                    semantic type: event
+                        - OntologyNode:
+                            name: natural_resources
+                            children:
+                                - OntologyNode:
+                                    definition: Fuels formed from natural processes, containing organic molecules, that release energy in combustion.
+                                    examples:
+                                        - carbon
+                                        - crude oil
+                                        - fossil fuels
+                                        - natural gas
+                                        - oil
+                                    name: fossil_fuels
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - groundwater
+                                    name: groundwater
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - acreage
+                                        - arable land
+                                        - farmland
+                                        - forestland
+                                        - land
+                                        - land resources
+                                        - plot
+                                    name: land
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    definition: Land used for grazing by domesticated livestock.
+                                    examples:
+                                        - grazing
+                                        - pastoral
+                                        - pasture
+                                        - rangeland
+                                        - vegetation
+                                    name: pasture
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - leaching into the soil
+                                        - soil
+                                        - soil types
+                                    name: soil
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - aqueduct
+                                        - lake
+                                        - ocean
+                                        - pond
+                                        - reservoir
+                                        - river
+                                        - water bodies
+                                    name: water_bodies
+                                    polarity: 1
+                                    semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - air pollution
+                                - contamination
+                                - greenhouse gas
+                                - land pollution
+                                - water pollution
+                            name: pollution
+                            polarity: -1
+                            semantic type: event
+                - OntologyNode:
+                    examples:
+                        - ethnic diversity
+                        - ethnic minorities
+                    name: ethnic_diversity
+                    polarity: 1
+                    semantic type: entity
+                - OntologyNode:
+                    examples:
+                        - freedom
+                    name: freedom
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    name: goods
+                    children:
+                        - OntologyNode:
+                            name: agricultural
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - compound feed
+                                        - compound poultry feed
+                                        - concentrate feed
+                                        - micronutrients
+                                        - oil cakes
+                                        - supplemental feed
+                                    name: compound_feed
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - farm equipment
+                                        - machinery
+                                        - plow
+                                        - power tiller
+                                        - row planter
+                                        - tractor
+                                        - winnower
+                                    name: farm_equipment
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - CSB
+                                        - corn meal
+                                        - hay
+                                        - livestock feed
+                                        - poultry feed
+                                        - silage
+                                        - soybean hulls
+                                    name: feed
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    patterns:
+                                        - \b(manure|fertilizers?|nitrogen)\b
+                                    examples:
+                                        - DAP
+                                        - compost
+                                        - fertilizer
+                                        - manure
+                                        - nitrogen
+                                        - phosphorous
+                                        - potassium
+                                        - urea
+                                    name: fertilizer
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - drip
+                                        - electric pump
+                                        - field irrigation
+                                        - irrigation equipment
+                                        - pump
+                                        - small scale irrigation pump
+                                        - sprinklers
+                                        - treadle
+                                        - water pumps
+                                    name: irrigation_equipment
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - animal production
+                                        - beef
+                                        - bone meal
+                                        - bovine meat
+                                        - broiler meat
+                                        - capita meat
+                                        - carcass weight
+                                        - chicken breast
+                                        - chicken feet
+                                        - chicken leg
+                                        - chicken meat
+                                        - chicken thigh
+                                        - commercial sector
+                                        - concept meat
+                                        - cultured meat
+                                        - dog
+                                        - fowl meat
+                                        - game
+                                        - goat meat
+                                        - livestock prices
+                                        - livestock products
+                                        - meat
+                                        - meat chickens
+                                        - meat exports
+                                        - meat imports
+                                        - meat industry
+                                        - meat meal
+                                        - meat output
+                                        - meat prices
+                                        - meat products
+                                        - meat sector
+                                        - meat yield
+                                        - meats
+                                        - more meat
+                                        - mutton
+                                        - offal
+                                        - other animals
+                                        - other foods
+                                        - other meat
+                                        - other meats
+                                        - ovine meat
+                                        - pig meat
+                                        - piglets
+                                        - pigmeat
+                                        - pork
+                                        - poultry meat
+                                        - processed meat
+                                        - red meat
+                                        - slaughter houses
+                                        - slaughterhouse
+                                        - slaughterhouses
+                                        - total meat
+                                        - turkeys
+                                        - white meat
+                                        - wild foods
+                                    name: meat
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    patterns:
+                                        - \b(DDT|dicamba|round-up)\b
+                                    examples:
+                                        - IPM
+                                        - chemical
+                                        - integrated pest management
+                                        - organic
+                                        - pesticide
+                                    name: pesticide
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - GMO
+                                        - heirloom seed
+                                        - improved seed
+                                        - organic seed
+                                        - seed
+                                    name: seed
+                                    polarity: 1
+                                    semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - concrete cement
+                                - construction materials
+                                - lumber
+                            name: construction_materials
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - chalkboard
+                                - education supplies
+                                - notebook
+                                - pencil
+                                - smartboard
+                                - textbooks
+                            name: education_supplies
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - bread
+                                - breakfast
+                                - broken rice
+                                - butter
+                                - cooking
+                                - diet
+                                - dietary
+                                - dish
+                                - dishes
+                                - food
+                                - garlic
+                                - herbs
+                                - meals
+                                - meat meal
+                                - menu
+                                - mixed dishes
+                                - noodles
+                                - onion
+                                - onions
+                                - pasta
+                                - plates
+                                - potato
+                                - potatoes
+                                - refrigerator
+                                - restaurant
+                                - rice bran
+                                - salt
+                                - snacks
+                                - soybean meal
+                                - spices
+                                - sweet potatoes
+                                - tomatoes
+                            name: food
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - fuel
+                                - gas
+                                - oil
+                            name: fuel
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - bandages
+                                - bed
+                                - blood
+                                - medical supplies
+                                - respirator
+                                - ventilator
+                            name: medical_supplies
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - antibiotics
+                                - antimicrobial
+                                - antiretroviral
+                                - antiviral
+                                - antivirals
+                                - aspirin
+                                - corticosteroid
+                                - drugs
+                                - medication
+                                - medicine
+                                - paracetamol
+                                - penicillin
+                                - pharmaceuticals
+                                - steroid
+                                - tetracycline
+                                - therapeutic
+                            name: medicine
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - aluminium
+                                - aluminum
+                                - cobalt
+                                - copper
+                                - diamond
+                                - gold
+                                - metal
+                                - mineral
+                                - ore
+                                - silver
+                                - zinc
+                            name: minerals
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - clean water
+                                - drinking water
+                                - fresh water
+                                - potable water
+                                - safe water
+                                - water quality
+                            name: potable_water
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - alfalfa
+                                - bean
+                                - dairy
+                                - eggs
+                                - fishmeal
+                                - groundnut
+                                - groundnuts
+                                - legume
+                                - meat
+                                - milk
+                                - sorghum
+                                - soy
+                                - soya
+                                - soya bean
+                                - soybean
+                                - soybean cake
+                                - soybean cakes
+                                - soybean meal
+                                - soybeans
+                                - sunflower
+                                - tilapia
+                                - yoghurt
+                                - yogurt
+                            name: protein_foods
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - H20
+                                - aqua
+                                - water
+                            name: water
+                            polarity: 1
+                            semantic type: entity
+                - OntologyNode:
+                    name: government
+                    children:
+                        - OntologyNode:
+                            name: corruption
+                            children:
+                                - OntologyNode:
+                                    name: corrupt_policy
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - cronyism
+                                                - favoritism
+                                                - nepotism
+                                                - party corruption
+                                                - policy favoritism
+                                                - political clientelist network
+                                                - political patronage
+                                            name: cronyism
+                                            polarity: 1
+                                            semantic type: event
+                                        - OntologyNode:
+                                            examples:
+                                                - campaign financing irregularities
+                                                - conflict of interest
+                                                - illegal contributions
+                                                - illicit contributions
+                                                - illicit political financing
+                                            name: illicit_political_financing
+                                            polarity: 1
+                                            semantic type: entity
+                                        - OntologyNode:
+                                            examples:
+                                                - bribery
+                                                - corrupt parliamentary oversight
+                                                - dereliction of duty
+                                                - fiscal irresponsibility
+                                                - parliamentary corruption
+                                                - parliamentary vote selling
+                                                - rent extraction
+                                                - rent seeking
+                                            name: parliamentary_corruption
+                                            polarity: 1
+                                            semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - ballot burning
+                                        - ballot stuffing
+                                        - corrupt campaigning
+                                        - deceptive campaign techniques
+                                        - election fraud
+                                        - election manipulation
+                                        - electoral fraud
+                                        - illegal campaigning
+                                        - rigged election
+                                        - violation of campaign laws
+                                        - vote buying
+                                        - vote manipulation
+                                        - voter fraud
+                                        - voter intimidation
+                                        - voter oppression
+                                    name: election_manipulation
+                                    polarity: 1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - arbitrary arrests
+                                        - bribery
+                                        - corruption
+                                        - disappearances
+                                        - extrajudicial killings
+                                        - impunity
+                                    name: government_corruption
+                                    polarity: 1
+                                    semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - decentralization
+                                - decentralize
+                            name: decentralization
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - foreign affairs
+                                - international affairs
+                                - international relations
+                                - international security
+                            name: diplomatic_relations
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - ballot
+                                - caucus
+                                - election
+                                - referendum
+                                - voting
+                            name: election
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - election cycle
+                                - election process
+                                - electoral cycle
+                                - electoral process
+                                - electoral system
+                            name: election_process
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - diplomats
+                                - foreign affairs
+                                - foreign aid
+                                - foreign policy
+                                - foreign relations
+                                - international security
+                                - political science
+                            name: foreign_policy
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - census
+                                - policy
+                                - program
+                                - psnp
+                                - safety net
+                                - social security
+                            name: government_program
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - court system
+                                - courthouse
+                                - judicial
+                                - judiciary
+                                - supreme court
+                                - tribunal
+                            name: judicial_system
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - act
+                                - appropriate policies
+                                - bill
+                                - bills
+                                - congress
+                                - constitution
+                                - directives
+                                - existing policies
+                                - filed
+                                - frameworks
+                                - laws
+                                - legislation
+                                - legislations
+                                - policies
+                                - priorities
+                                - provisions
+                                - regulations
+                                - regulatory frameworks
+                                - schedules
+                                - sector policies
+                            name: legislation
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - political influence
+                                - political power
+                            name: political_power
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - authoritarianism
+                                - autocracy
+                                - democracy
+                                - dictatorship
+                                - hegemony
+                                - imperialism
+                                - political
+                                - politics
+                                - reforms
+                                - regime
+                                - reign
+                            name: political_system
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - polling staff
+                                - polling station
+                                - polling stations
+                            name: polling_stations
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            definition: A restriction on trade, or measures by a country on a state or individual intended to elicit a change in their behavior.
+                            examples:
+                                - sanction
+                            name: sanction
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - failed states
+                                - state collapse
+                                - state failure
+                            name: state_collapse
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - central authority
+                                - congressional power
+                                - executive power
+                                - judicial power
+                                - parliamentary power
+                                - state authority
+                                - state control
+                                - state institutions
+                                - state power
+                                - state-building
+                            name: state_power
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - government change
+                            name: transition_of_power
+                            polarity: 1
+                            semantic type: event
+                - OntologyNode:
+                    name: health
+                    children:
+                        - OntologyNode:
+                            examples:
+                                - antibodies
+                                - antibody
+                                - antigens
+                            name: antibody
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - DNA
+                                - biometrics
+                                - fingerprint
+                            name: biometrics
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            patterns:
+                                - \b(case\s+volume)\b
+                                - \b(new\s+cases)\b
+                            examples:
+                                - caseload
+                                - confirmed cases
+                                - disease cases
+                                - new cases
+                                - reported cases
+                                - severe cases
+                                - suspected cases
+                            name: case_volume
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            name: disease
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - aids
+                                        - hiv
+                                    name: AIDS
+                                    polarity: -1
+                                    semantic type: event
+                                - OntologyNode:
+                                    patterns:
+                                        - (COVID|covid|SARS-CoV)
+                                        - corona(\s+)?virus
+                                    examples:
+                                        - corona virus
+                                        - coronavirus
+                                        - novel coronavirus
+                                        - virus
+                                    name: COVID
+                                    polarity: -1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - flu
+                                        - influenza
+                                    name: flu
+                                    polarity: -1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - anaemia
+                                        - cancer
+                                        - chikunguya
+                                        - congestion
+                                        - diarrhea
+                                        - episodes
+                                        - gross lesions
+                                        - illness
+                                        - inflammation
+                                        - lesions
+                                        - measles
+                                        - mers
+                                        - organs
+                                        - pathology
+                                        - pox
+                                        - salmonella
+                                        - sars
+                                        - sickness
+                                        - survivors
+                                        - tb
+                                        - tissue
+                                        - tsetse
+                                        - tuberculosis
+                                        - vessels
+                                        - zika
+                                    name: illness
+                                    polarity: -1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - malaria
+                                    name: malaria
+                                    polarity: -1
+                                    semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - alleles
+                                - carriers
+                                - clade
+                                - gene
+                                - genes
+                                - genetic characterization
+                                - genetic distance
+                                - genetic improvement
+                                - genetic material
+                                - genetic potential
+                                - genetic resistance
+                                - genetic resources
+                                - genetic selection
+                                - genetic variation
+                                - genome
+                                - locus
+                                - major genes
+                                - markers
+                                - mutation
+                                - mutations
+                                - phenotypes
+                                - snps
+                            name: gene
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - health
+                                - healthcare
+                                - medical
+                            name: healthcare
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - PPE
+                                - face covering
+                                - hand sanitizer
+                                - hygiene materials
+                                - masks
+                                - personal protective equipment
+                                - soap
+                            name: hygiene_materials
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - injury
+                                - wound
+                            name: injury
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - assessments
+                                - characterization
+                                - diagnostic confirmation
+                                - diagnostic tests
+                                - diagnostics
+                                - examination
+                                - further analysis
+                                - inspection
+                                - investigation
+                                - isolation
+                                - lab
+                                - laboratories
+                                - laboratory
+                                - laboratory testing
+                                - monitor
+                                - pcr
+                                - probe
+                                - records
+                                - sample collection
+                                - screening
+                                - separation
+                                - sequencing
+                                - test
+                                - testing
+                                - tests
+                            name: laboratory_testing
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - life
+                                - lives
+                                - living
+                            name: life
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - acute malnutrition
+                                - gam
+                                - gam whz
+                                - global acute malnutrition
+                                - haz
+                                - hdds
+                                - height for age
+                                - hhs
+                                - household dietary diversity score
+                                - household hunger scale
+                                - hunger
+                                - malnourished
+                                - stunting
+                                - wasting
+                                - weight for height
+                                - whz
+                            name: malnutrition
+                            polarity: -1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - DALY
+                                - disability
+                                - disability adjusted life year
+                                - high morbidity
+                                - morbidity
+                            name: morbidity
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - adequate amounts
+                                - bioavailability
+                                - calories
+                                - carbohydrates
+                                - chemicals
+                                - cholesterol
+                                - compounds
+                                - diets
+                                - ectoparasites
+                                - energy
+                                - essential micronutrients
+                                - essential nutrients
+                                - ethiochicken
+                                - folate
+                                - ingredient
+                                - iodine
+                                - ldc
+                                - lysine
+                                - macronutrients
+                                - metabolism
+                                - methionine
+                                - micronutrient adequacy
+                                - mycotoxins
+                                - nutrient
+                                - nutrient requirements
+                                - nutrients
+                                - oils
+                                - other components
+                                - other nutrients
+                                - phosphorus
+                                - protein
+                                - quantities
+                                - reagents
+                                - requirement
+                                - requirements
+                                - riboflavin
+                                - selenium
+                                - substances
+                                - supplementation
+                                - supplements
+                                - threonine
+                                - vitamin
+                                - vitamin a
+                                - vitamins
+                            name: nutrients
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - bioavailability
+                                - diet
+                                - nutrient content
+                                - nutrition outcomes
+                                - nutritional needs
+                                - nutritional requirements
+                                - nutritional value
+                                - obesity
+                            name: nutrition
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - bacteria
+                                - bacterium
+                                - bovine brucellosis
+                                - brucellosis
+                                - contagions
+                                - cysts
+                                - echinococcosis
+                                - external parasites
+                                - fomites
+                                - fungal
+                                - fungus
+                                - germplasm
+                                - germs
+                                - microbe
+                                - mycobacterium
+                                - mycoplasmosis
+                                - mycotoxins
+                                - parasite
+                                - pathogen
+                                - pathogens
+                                - salmonella
+                                - salmonellosis
+                                - toxins
+                                - trypanosomes
+                                - virus
+                                - zoonotic pathogens
+                            name: pathogen
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - child mortality
+                                - child stunting
+                                - infant mortality
+                                - lbw
+                                - stunting
+                            name: poor_childrens_health
+                            polarity: -1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - crude protein
+                                - protein
+                                - protein content
+                                - protein requirements
+                                - protein source
+                                - protein sources
+                            name: protein_nutrient
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - population health
+                                - public health
+                            name: public_health
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - public safety
+                            name: public_safety
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - alcohol abuse
+                                - cocaine
+                                - drugs abuse
+                                - heroin
+                                - narcotics
+                                - prescription drug abuse
+                                - substance abuse
+                            name: substance_abuse
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            name: treatment
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - intensive care
+                                    name: intensive_care
+                                    polarity: 1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - preventative treatment
+                                        - prophylactic
+                                        - vaccine
+                                        - well visit
+                                    name: preventative_treatment
+                                    polarity: 1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - anti-depressant
+                                        - counseling
+                                        - psychiatrist
+                                        - psychological services
+                                        - psychotherapy
+                                        - therapy
+                                    name: psychological_services
+                                    polarity: 1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - additional feed
+                                        - cumulative feed
+                                        - feed
+                                        - feed conversion
+                                        - feed requirements
+                                        - feed resources
+                                        - feed supplementation
+                                        - feed supplements
+                                        - improved feed
+                                        - more feed
+                                        - supplemental feed
+                                        - supplementary feed
+                                        - supplementary feeding
+                                    name: supplemental_feed
+                                    polarity: 1
+                                    semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - cell
+                                - covax
+                                - immunization
+                                - inoculation
+                                - ndv vaccines
+                                - recombinant vaccines
+                                - strain
+                                - syringe
+                                - syringes
+                                - vaccinated
+                                - vaccination
+                                - vaccinations
+                                - vaccinator
+                                - vaccinators
+                                - vaccine
+                                - vat
+                                - virology
+                            name: vaccination
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            definition: An agent that carries or transmits an infectious pathogen into another living organism.
+                            examples:
+                                - excrement
+                                - mosquitos
+                                - transmission
+                                - vector
+                                - water
+                            name: vector
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - body size
+                                - body weight
+                                - body weights
+                                - bone
+                                - carcass characteristics
+                                - conversion ratio
+                                - function
+                                - growth
+                                - muscle
+                                - weight
+                                - weight gain
+                                - weight loss
+                                - weights
+                            name: weight_gain
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - living condition
+                                - welfare
+                            name: welfare
+                            polarity: 1
+                            semantic type: event
+                - OntologyNode:
+                    examples:
+                        - homeless
+                    name: homelessness
+                    polarity: -1
+                    semantic type: entity
+                - OntologyNode:
+                    examples:
+                        - freedom
+                        - freedoms
+                        - human rights
+                        - liberties
+                        - liberty
+                    name: human_rights
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    name: humanitarian_assistance
+                    children:
+                        - OntologyNode:
+                            examples:
+                                - CSB
+                                - food aid
+                                - food for work
+                                - free food distribution
+                                - nutrition assistance
+                                - ration
+                                - school feeding
+                            name: food_aid
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - development assistance
+                                - emergency aid
+                                - emergency response
+                                - foreign assistance
+                                - humanitarian aid
+                                - humanitarian assistance
+                                - humanitarian interventions
+                                - international aid
+                                - urgent assistance
+                            name: humanitarian_assistance
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - NFI
+                                - buckets
+                                - jerry can
+                                - non food items
+                                - pans
+                                - pots
+                                - soap
+                                - tarp
+                            name: non_food_items
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            patterns:
+                                - \bcash\b
+                                - \bvouchers?\b
+                            examples:
+                                - cash assistance
+                                - food voucher
+                                - livelihood assistance
+                                - voucher or cash
+                            name: voucher_or_cash
+                            polarity: 1
+                            semantic type: event
+                - OntologyNode:
+                    examples:
+                        - discrepancy
+                        - disparity
+                        - imbalance
+                        - inequality
+                        - inequity
+                    name: inequality
+                    polarity: -1
+                    semantic type: event
+                - OntologyNode:
+                    name: information
+                    children:
+                        - OntologyNode:
+                            examples:
+                                - computers
+                                - digital technologies
+                                - information technology
+                            name: information_technology
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - intelligence
+                                - intelligence analysis
+                                - intelligence information
+                            name: intelligence_information
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - internet
+                                - mobile internet
+                                - web
+                                - world wide web
+                            name: internet
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - disinformation
+                                - fake news
+                                - false reporting
+                                - falsehood
+                                - misconception
+                                - misinformation
+                                - misreporting
+                            name: misinformation
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - allegation
+                                - myth
+                                - narrative
+                                - rumor
+                                - rumour
+                                - speculation
+                            name: rumor
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - facebook
+                                - instagram
+                                - social media
+                                - twitter
+                            name: social_media
+                            polarity: 1
+                            semantic type: entity
+                - OntologyNode:
+                    name: infrastructure
+                    children:
+                        - OntologyNode:
+                            name: agriculture
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - barn
+                                        - farm infrastructure
+                                        - greenhouse
+                                        - livestock enclosure
+                                        - nursery
+                                        - post harvest infrastructure
+                                    name: farm_infrastructure
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - agricultural land
+                                        - arable land
+                                        - farmland
+                                    name: farmland
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - broiler producers
+                                        - poultry producers
+                                        - salvage slaughter
+                                        - slaughter
+                                        - slaughter facilities
+                                        - slaughter houses
+                                        - slaughterhouse
+                                        - slaughterhouses
+                                        - slaughtering
+                                    name: slaughterhouse
+                                    polarity: 1
+                                    semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - advertisement
+                                - article
+                                - bandwidth
+                                - booklet
+                                - channel
+                                - communication
+                                - email
+                                - facebook
+                                - forum
+                                - intranet
+                                - magazine
+                                - media
+                                - networking
+                                - news
+                                - newsgroup
+                                - newspaper
+                                - online
+                                - pamphlet
+                                - poster
+                                - publication
+                                - speech
+                                - telecom
+                                - telecommunications
+                                - telephone
+                                - television
+                            name: communication
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - campus
+                                - child friendly learning spaces
+                                - classroom
+                                - college
+                                - community centers
+                                - education facilities
+                                - faculty
+                                - institute
+                                - kindergarten
+                                - lecture hall
+                                - school
+                                - university
+                            name: education_facilities
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - electrical wiring
+                                - electricity
+                                - generator
+                                - lighting
+                                - power grid
+                                - power line
+                                - solar panel
+                            name: electrical_infrastructure
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - electricity
+                                - energy
+                                - hydropower
+                                - wind power
+                            name: energy
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - dam
+                                - energy
+                                - generator
+                                - micro grid
+                                - power plant
+                                - power station
+                                - solar panel
+                                - wind turbine
+                            name: energy_infrastructure
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - dike
+                                - flood wall
+                                - levee
+                                - seawall
+                            name: flood_mitigation_infrastructure
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - buildings
+                                - floors
+                                - housing
+                                - roof
+                                - roofs
+                                - rooms
+                                - walls
+                                - windows
+                            name: housing
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            patterns:
+                                - irrigation
+                            examples:
+                                - canal
+                                - irrigation
+                            name: irrigation_infrastructure
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            patterns:
+                                - \bclinics\b
+                                - \bhospitals?\b
+                            examples:
+                                - basic health services
+                                - care facilities
+                                - care services
+                                - care system
+                                - care workers
+                                - clinic
+                                - doctors office
+                                - field hospitals
+                                - health centre
+                                - health facility
+                                - health post
+                                - hospital
+                                - medical facilities
+                                - mobile clinics
+                            name: medical_facilities
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - mine
+                                - mineshaft
+                            name: mining_infrastructure
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            patterns:
+                                - \bcamps?\b
+                                - \brefugee\s+camps?\b
+                            examples:
+                                - idp camps
+                                - refugee camp
+                                - refugee settlements
+                                - temporary housing
+                            name: refugee_camps
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            patterns:
+                                - \blatrines?\b
+                                - \btoilets?\b
+                            examples:
+                                - handwashing station
+                                - latrines
+                                - sanitation
+                                - toilets
+                            name: sanitation_infrastructure
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            name: transportation
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - bridge
+                                    name: bridge
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - public transport
+                                        - public transportation
+                                    name: public_transportation
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - rail
+                                        - railroad
+                                        - train
+                                    name: railroad_infrastructure
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - highway
+                                        - road
+                                        - trucking
+                                        - trucks
+                                    name: road_infrastructure
+                                    polarity: 1
+                                    semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - ballot boxes
+                                - polling booths
+                                - voting locations
+                                - voting systems
+                                - voting tools
+                            name: voting_infrastructure
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            patterns:
+                                - \bborehole
+                            examples:
+                                - boreholes
+                                - water facilities
+                                - water point
+                                - water treatment center
+                                - wells
+                            name: water_facilities
+                            polarity: 1
+                            semantic type: entity
+                - OntologyNode:
+                    examples:
+                        - appropriate technologies
+                        - different approaches
+                        - existing technologies
+                        - improved technologies
+                        - innovations
+                        - innovative approaches
+                        - modern technologies
+                        - new approach
+                        - new approaches
+                        - new ideas
+                        - new markets
+                        - new practices
+                        - new technologies
+                        - new technology
+                        - new tools
+                        - new ways
+                        - technologies
+                    name: innovation
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - approaches
+                        - appropriate actions
+                        - appropriate interventions
+                        - appropriate technologies
+                        - choices
+                        - different interventions
+                        - different strategies
+                        - efforts
+                        - intervention
+                        - intervention options
+                        - intervention strategies
+                        - interventions
+                        - other interventions
+                        - other methods
+                        - participatory approaches
+                        - possible solutions
+                        - programmes
+                        - project interventions
+                        - proposed interventions
+                        - solutions
+                        - specific interventions
+                        - strategies
+                        - such efforts
+                        - such interventions
+                        - such programmes
+                        - tactics
+                        - tools
+                        - traditional methods
+                        - wash interventions
+                    name: intervention
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - literacy
+                    name: literacy
+                    polarity: 1
+                    semantic type: entity
+                - OntologyNode:
+                    examples:
+                        - antimicrobials
+                        - biotechnologies
+                        - biotechnology
+                        - fungi
+                        - gram
+                        - microbes
+                        - microbiology
+                        - microorganisms
+                        - organism
+                        - probiotics
+                        - termites
+                    name: microbiology
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - opinion
+                        - perception
+                        - perceptions
+                    name: perception
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - action
+                        - action plan
+                        - agenda
+                        - climate plan
+                        - development strategy
+                        - horizon
+                        - initiative
+                        - master
+                        - national policy
+                        - new deal
+                        - path
+                        - plan
+                        - priority
+                        - program
+                        - response plan
+                        - roadmap
+                        - roadmaps
+                        - strategic plan
+                        - strategic planning
+                        - transformation plan
+                        - vision
+                        - work plans
+                    name: plan
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - decision making
+                        - policy
+                        - policy changes
+                        - policy interventions
+                        - policy makers
+                        - policymaking
+                    name: policy_making
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    name: population_demographics
+                    children:
+                        - OntologyNode:
+                            examples:
+                                - age
+                            name: age
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - clan
+                                - family
+                            name: clan
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - ethnic identities
+                                - ethnic identity
+                                - identities
+                                - identity
+                                - identity groups
+                            name: ethnic_identity
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - empowerment
+                                - equal opportunities
+                                - female
+                                - gender
+                                - gender analysis
+                                - gender demographics
+                                - gender dimensions
+                                - gender equality
+                                - gender focus
+                                - gender issues
+                                - inclusiveness
+                                - male
+                                - sex
+                                - sexes
+                                - social determinants
+                            name: gender
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            name: population_density
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - de-population
+                                        - depopulation
+                                        - population decline
+                                    name: de-population
+                                    polarity: -1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - overcrowding
+                                    name: overcrowding
+                                    polarity: 1
+                                    semantic type: entity
+                                - OntologyNode:
+                                    examples:
+                                        - population growth
+                                    name: population_growth
+                                    polarity: 1
+                                    semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - ethnicity
+                                - race
+                            name: race_or_ethnicity
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - religion
+                            name: religion
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - ethnicity
+                                - tribal
+                                - tribe
+                            name: tribe
+                            polarity: 1
+                            semantic type: entity
+                - OntologyNode:
+                    examples:
+                        - poor communities
+                        - poor consumers
+                        - poor countries
+                        - poor families
+                        - poor households
+                        - poorer households
+                        - poorest households
+                        - poverty
+                    name: poverty
+                    polarity: -1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - bans
+                        - ceilings
+                        - controls
+                        - cuts
+                        - penalties
+                        - regulations
+                        - related restrictions
+                        - restrictions
+                        - restrictive measures
+                        - sanctions
+                    name: regulations
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - celebration
+                        - ceremony
+                        - commemoration
+                        - festival
+                        - funeral
+                        - holiday
+                        - observance
+                        - ritual
+                    name: ritual
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - basic services
+                        - civil registration
+                        - entitlements
+                        - essential services
+                        - pensions
+                        - social assistance
+                        - social benefits
+                        - social protection
+                        - social services
+                        - vouchers
+                        - welfare
+                    name: safety_net
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - carcasses
+                        - culling
+                        - spoilage
+                    name: scavenging_system
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    name: security
+                    children:
+                        - OntologyNode:
+                            examples:
+                                - community
+                                - mine clearance
+                                - policing
+                            name: community_security
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - depreciation
+                                - economic security
+                                - economy
+                                - inflation
+                                - recession
+                            name: economic_security
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - environmental security
+                            name: environmental_security
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - diplomacy
+                                - military
+                                - national security
+                            name: national_security
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - informant
+                                - monitor
+                                - spy
+                                - surveillance system
+                                - track
+                            name: surveillance_system
+                            polarity: 1
+                            semantic type: event
+                - OntologyNode:
+                    examples:
+                        - cultural factors
+                        - individual characteristics
+                        - marital status
+                        - personal relationships
+                        - power relations
+                        - social capital
+                        - social cohesion
+                        - social factors
+                        - social groups
+                        - social interactions
+                        - social networks
+                        - social practices
+                        - social relations
+                        - social relationships
+                        - social sciences
+                        - social scientists
+                        - social status
+                        - social structure
+                        - social systems
+                        - symbolic boundaries
+                        - ties
+                    name: social_structure_or_relationship
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    name: storage
+                    children:
+                        - OntologyNode:
+                            examples:
+                                - agricultural storage
+                                - granary
+                                - silo
+                                - warehouse
+                            name: agricultural_storage
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - storage
+                                - storage facilities
+                                - warehouse
+                            name: general_storage_facilities
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - household food storage
+                                - storage
+                            name: household_food_storage
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - stockpile
+                            name: stockpile_goods
+                            polarity: 1
+                            semantic type: entity
+                - OntologyNode:
+                    name: time
+                    children:
+                        - OntologyNode:
+                            examples:
+                                - delay
+                                - halt
+                                - postpone
+                                - stall
+                                - suspend
+                            name: delay
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - arid
+                                - drought
+                                - dry season
+                                - dry spells
+                                - drylands
+                                - summer
+                            name: dry_season
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - ongoing
+                                - prolonged
+                                - protracted
+                            name: prolonged
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - crop calendar
+                                - crop season
+                                - harvesting season
+                                - lean season
+                                - planting season
+                                - season
+                            name: season
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - long rains
+                                - monsoon
+                                - rainfall
+                                - rainy seasons
+                                - wet
+                                - wet seasons
+                            name: wet_season
+                            polarity: 1
+                            semantic type: event
+                - OntologyNode:
+                    examples:
+                        - bias
+                        - demographics
+                        - fluctuations
+                        - pattern
+                        - percentage change
+                        - trend
+                    name: trend
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - attendance
+                        - turnout
+                    name: turnout
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - urbanization
+                    name: urbanization
+                    polarity: 1
+                    semantic type: event
+        - OntologyNode:
+            name: process
+            children:
+                - OntologyNode:
+                    definition: The ability or right to approach, enter, exit, make use of, or communicate with something.
+                    examples:
+                        - access
+                    name: access
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - adapt
+                        - adaptability
+                        - adaptation
+                        - flexibility
+                    name: adapt
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - aid
+                        - assist
+                        - assistance
+                        - help
+                        - support
+                    name: aid_or_assistance
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - analyze
+                        - assess
+                        - critique
+                        - evaluate
+                    name: assessment
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - attempt
+                        - campaign
+                        - effort
+                        - initiative
+                        - program
+                        - try
+                    name: attempt
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - breed
+                        - breeder
+                        - breeding
+                        - brooder
+                        - broodiness
+                        - brooding
+                        - chick survival
+                        - cocks
+                        - crossbred
+                        - crossbreed
+                        - crossbreeding
+                        - domestication
+                        - egg offtake
+                        - egg size
+                        - generation
+                        - grandparent stock
+                        - growing phase
+                        - hatchability
+                        - hatchery
+                        - hatching
+                        - inbreeding
+                        - laying
+                        - laying hens
+                        - mating
+                        - maturation
+                        - next generation
+                        - offspring
+                        - parent stock
+                        - phenotype
+                        - progeny
+                        - rearers
+                        - rearing
+                        - reproductive stages
+                        - roosters
+                        - semen
+                        - stud
+                    name: breeding
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - censorship
+                    name: censorship
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - clean
+                        - clean up
+                        - cleanse
+                        - sanitization
+                        - sanitize
+                        - wash
+                    name: clean
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - alliance
+                        - allied
+                        - ally
+                        - coalition
+                        - collaborate
+                        - collaboration
+                        - cooperate
+                        - partner
+                        - partnership
+                    name: collaboration
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - collect
+                        - collecting
+                        - collection
+                        - compile
+                        - gather
+                        - hoard
+                    name: collecting
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - combine
+                        - couple
+                        - incorporate
+                        - integrate
+                        - link
+                        - merge
+                        - mix
+                    name: combining
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    name: communication
+                    children:
+                        - OntologyNode:
+                            name: ask
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - canvass
+                                        - poll
+                                    name: poll
+                                    polarity: 1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - ask
+                                        - interrogate
+                                        - interview
+                                        - question
+                                    name: question
+                                    polarity: 1
+                                    semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - advocate
+                                - campaign
+                                - convince
+                                - encourage
+                                - lobbying
+                                - persuade
+                                - promote
+                            name: campaign
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - commit
+                                - commitment
+                                - pledge
+                                - promise
+                            name: commitment
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - argue
+                                - assert
+                                - contend
+                                - debate
+                                - disagree
+                                - discuss
+                                - fight
+                            name: debate
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - deceive
+                                - deception
+                                - deceptive
+                                - 'false'
+                                - misinform
+                            name: deception
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - describe
+                                - description
+                                - discuss
+                                - illustrate
+                                - outline
+                                - report
+                                - summarize
+                            name: description
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - advocate
+                                - approve
+                                - endorse
+                                - endorsement
+                                - espouse
+                                - support
+                            name: endorsement
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - distinguish
+                                - emphasise
+                                - emphasize
+                                - highlight
+                            name: highlighting
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - disclose
+                                - inform
+                                - report
+                                - say
+                                - speak
+                                - tell
+                            name: informing
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - arbitrate
+                                - broker
+                                - mediate
+                                - mediation
+                                - referee
+                            name: mediation
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - assembly
+                                - conference
+                                - consult
+                                - convene
+                                - conversation
+                                - dialogue
+                                - discuss
+                                - forum
+                                - meeting
+                                - roundtable
+                                - seminar
+                                - summit
+                                - workshop
+                            name: meeting
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - bargain
+                                - negotiate
+                                - negotiation
+                            name: negotiation
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - challenge
+                                - condemn
+                                - criticise
+                                - criticize
+                                - critique
+                                - debunk
+                                - denounce
+                                - dismiss
+                                - dispute
+                                - mock
+                                - oppose
+                                - opposition
+                                - question
+                                - refute
+                                - reject
+                                - renounce
+                                - subvert
+                            name: opposition
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - recommend
+                                - recommendation
+                                - suggest
+                                - suggestion
+                            name: suggestion
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - caution
+                                - warn
+                                - warning
+                            name: warning
+                            polarity: 1
+                            semantic type: event
+                - OntologyNode:
+                    name: conflict
+                    children:
+                        - OntologyNode:
+                            examples:
+                                - abducted
+                                - abduction
+                                - child abductions
+                                - forced recruitment
+                                - hostage taking
+                                - kidnapped
+                                - kidnapping
+                                - ransomed
+                            name: abduction
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - abuse
+                                - harass
+                                - neglect
+                                - persecute
+                                - violate
+                            name: abuse
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - assassinate
+                                - assassination
+                            name: assassination
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - airstrike
+                                - ambush
+                                - assault
+                                - attack
+                                - attacked
+                                - attacking
+                                - attacks
+                                - battle
+                                - bombard
+                                - clash
+                                - combat
+                                - crossfire
+                                - destroyed in combat
+                                - fight
+                                - genocide
+                                - invaded
+                                - invasion
+                                - massacre
+                                - offense
+                                - psychological warfare
+                                - raiding
+                                - shooting
+                                - shoots
+                                - strike
+                            name: attack
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - clan conflict
+                                - clan differences
+                                - clan tensions
+                            name: clan_conflict
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - crackdown
+                                - crush
+                                - overreact
+                                - repress
+                                - suppress
+                            name: crackdown
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - collapse
+                                - coup
+                                - defeat
+                                - demise
+                                - depose
+                                - dissolution
+                                - exile
+                                - oust
+                                - overthrow
+                                - topple
+                            name: defeat
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - ceasefire
+                                - disarmament
+                            name: disarmament
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - discriminate
+                                - exclude
+                                - marginalize
+                                - profile
+                                - segregate
+                                - stigmatize
+                            name: discriminate
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - draft
+                                - enlist
+                                - marshal
+                                - muster
+                                - recruit
+                            name: enlist
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            definition: To make use of (sometimes unfairly) to one's own advantage.
+                            examples:
+                                - cheat
+                                - coerce
+                                - exploit
+                                - intimidate
+                                - lure
+                                - manipulate
+                            name: exploit
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - harass
+                                - harassment
+                                - persecute
+                                - persecution
+                            name: harass_or_persecute
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - insurgency
+                                - revolt
+                                - uprising
+                            name: insurgency
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - conflict prevention
+                                - conflict resolution
+                                - diplomacy
+                                - dispute resolution
+                                - international covenant
+                                - peace building
+                                - peace negotiations
+                                - peace talks
+                                - peacebuilding
+                                - peacebuilding activities
+                                - peacebuilding efforts
+                                - peacebuilding initiatives
+                                - peacebuilding processes
+                                - peacemaking
+                                - stabilization activities
+                                - stabilization efforts
+                                - statebuilding
+                                - treaty
+                            name: peacebuilding
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - peacekeepers
+                                - peacekeeping
+                            name: peacekeeping
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - police brutality
+                            name: police_brutality
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - assemble
+                                - boycott
+                                - civil unrest
+                                - clash
+                                - crowd
+                                - demands
+                                - gather
+                                - peaceful assembly
+                                - picket
+                                - protest
+                                - rally
+                                - riot
+                                - social unrest
+                                - strikes
+                                - turmoil
+                            name: protest_or_demonstration
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - accord
+                                - accords
+                                - agreement
+                                - cessation
+                                - compromise
+                                - conciliation
+                                - deal
+                                - pact
+                                - peace deal
+                                - peacebuilding
+                                - peacekeeping
+                                - pledge
+                                - rapprochement
+                                - resolution
+                                - treaty
+                            name: resolution
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - retaliation
+                                - retribution
+                                - revenge
+                            name: retaliation
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - bomb threat
+                                - extremism
+                                - guerilla
+                                - insurgency
+                                - political terror
+                                - roadside bombing
+                                - terrorism
+                                - terrorist activity
+                                - terrorist acts
+                                - terrorist attack
+                                - violent extremism
+                            name: terrorism
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - intimidate
+                                - threat
+                                - threaten
+                            name: threat
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - excessive force
+                                - torture
+                            name: torture
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - ethnic conflict
+                                - ethnic conflicts
+                                - ethnic differences
+                                - ethnic divisions
+                                - ethnic hatred
+                                - ethnic lines
+                                - ethnic tensions
+                                - ethnic violence
+                                - historical conflict
+                                - intergroup conflict
+                                - tribal conflict
+                            name: tribal_conflict
+                            polarity: -1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - assault
+                                - attack
+                                - bombard
+                                - civil war
+                                - clash
+                                - genocide
+                                - invaded
+                                - military aggression
+                                - rebel
+                                - war
+                                - warfare
+                                - warlord
+                            name: war
+                            polarity: -1
+                            semantic type: event
+                - OntologyNode:
+                    examples:
+                        - build
+                        - building
+                        - construct
+                        - construction
+                        - establish
+                    name: construction
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - consume
+                        - consumption
+                        - household consumption
+                        - own consumption
+                        - use
+                    name: consumption
+                    polarity: -1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - damage
+                        - devastate
+                        - ravage
+                    name: damage
+                    polarity: -1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - conclude
+                        - decide
+                        - decision
+                    name: decision
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - demand
+                        - petition
+                        - request
+                    name: demand
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - deploy
+                        - deployment
+                        - dispatch
+                    name: deployment
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - depreciate
+                        - devaluation
+                    name: depreciation
+                    polarity: -1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - destabilize
+                    name: destabilization
+                    polarity: -1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - destroy
+                        - destruction
+                        - ruin
+                    name: destruction
+                    polarity: -1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - clinical signs
+                        - detect
+                        - detection
+                        - diagnose
+                        - diagnostics
+                        - signs
+                    name: detection
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - broaden
+                        - cultivate
+                        - develop
+                        - development
+                        - expand
+                        - extend
+                        - grow
+                        - growth
+                    name: development
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - conceal
+                        - disguise
+                        - evade
+                        - hide
+                        - mask
+                        - shield
+                        - stealth
+                    name: disguise
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - boost
+                        - enhance
+                        - enhancement
+                        - enrich
+                        - enrichment
+                        - improve
+                        - improvement
+                        - supplement
+                        - upgrade
+                    name: enhancement
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - evacuate
+                        - evacuation
+                    name: evacuation
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - dispossession
+                        - eviction
+                    name: eviction
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - discovery
+                        - experimentation
+                        - exploration
+                        - findings
+                        - investigation
+                    name: exploration
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - compose
+                        - derive
+                        - extract
+                        - isolate
+                        - source
+                        - synthesize
+                    name: extraction
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    name: farming
+                    children:
+                        - OntologyNode:
+                            examples:
+                                - harvest
+                                - harvesting
+                                - reap
+                            name: harvesting
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - grazing
+                                - herders
+                                - herding
+                                - herds
+                            name: herding
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            definition: The process of applying controlled amounts of water to plants.
+                            examples:
+                                - irrigate
+                                - irrigating
+                                - irrigation
+                            name: irrigation
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - cultivate
+                                - planting
+                                - sow
+                            name: planting
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - tilling
+                            name: tilling
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - weeding
+                            name: weeding
+                            polarity: 1
+                            semantic type: event
+                - OntologyNode:
+                    examples:
+                        - aquaculture
+                        - fish
+                        - fisheries
+                        - fishing
+                    name: fishing
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - diffuse
+                        - diffusion
+                        - flow
+                        - trickle
+                    name: flow
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - forage
+                    name: foraging
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - band
+                        - categorize
+                        - classify
+                        - cluster
+                        - group
+                        - subdivide
+                    name: grouping
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - abundance
+                        - chick survival
+                        - egg productivity
+                        - fitness
+                        - growth performance
+                        - growth rate
+                        - hatch
+                        - hatching
+                        - mortality
+                        - reproductive performance
+                        - survival
+                        - survival rate
+                        - survival rates
+                    name: hatching
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - hunt
+                        - poaching
+                    name: hunting
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - arrest
+                        - captivity
+                        - capture
+                        - custody
+                        - detain
+                        - detention
+                        - enslave
+                        - imprison
+                        - imprisonment
+                        - incarcerate
+                    name: imprisonment_or_detention
+                    polarity: -1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - artificial incubation
+                        - brooder
+                        - brooders
+                        - free range
+                        - grower phase
+                        - growing period
+                        - incubation
+                        - incubation period
+                        - incubator
+                        - incubators
+                        - natural incubation
+                        - poults
+                        - rearing
+                        - restocking
+                    name: incubation
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    patterns:
+                        - \b[iI]nfest
+                    examples:
+                        - infest
+                        - infestation
+                    name: infestation
+                    polarity: -1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - inflation
+                    name: inflation
+                    polarity: -1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - inhabit
+                        - live
+                        - occupancy
+                        - reside
+                        - settle
+                    name: inhabiting_or_occupancy
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - consumption
+                        - eating
+                        - intake
+                    name: intake
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - audit
+                        - inquiry
+                        - investigate
+                        - investigation
+                    name: investigate
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - FDI
+                        - foreign direct investment
+                        - fund
+                        - invest
+                        - investment
+                        - spend
+                    name: investment
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    name: judicial
+                    children:
+                        - OntologyNode:
+                            examples:
+                                - charge
+                                - indict
+                                - prosecute
+                            name: charge_or_prosecution
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - convict
+                                - conviction
+                                - fine
+                                - jail
+                                - penalize
+                                - penalty
+                                - punish
+                                - sentence
+                                - sentencing
+                            name: conviction_or_sentencing
+                            polarity: 1
+                            semantic type: event
+                - OntologyNode:
+                    name: legislation
+                    children:
+                        - OntologyNode:
+                            patterns:
+                                - \b(regulations?|laws?)\b
+                            examples:
+                                - control
+                                - legislate
+                                - mandate
+                                - regulate
+                                - regulatory framework
+                                - repeal
+                                - restrict
+                            name: regulation
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - subsidize
+                                - subsidy
+                            name: subsidization
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - duty
+                                - levy
+                                - tariff
+                                - tax
+                                - taxation
+                            name: taxation
+                            polarity: 1
+                            semantic type: event
+                - OntologyNode:
+                    examples:
+                        - NRM
+                        - administrate
+                        - command
+                        - manage
+                        - management
+                        - oversee
+                    name: management
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - control
+                        - exploit
+                        - influence
+                        - manipulate
+                    name: manipulation
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    name: medical
+                    children:
+                        - OntologyNode:
+                            patterns:
+                                - (contact tracing)
+                            examples:
+                                - contact tracing
+                            name: contact_tracing
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - lockdown
+                            name: lockdown
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            patterns:
+                                - (quarantin|shelter[- ]in[- ]place)
+                                - \b(restrict\s+movement)
+                            examples:
+                                - isolation
+                                - quarantine
+                            name: quarantine
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - cleaning
+                                - disinfect
+                                - disinfection
+                                - sanitization
+                                - sanitize
+                            name: sanitization
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            patterns:
+                                - (social distanc)
+                            examples:
+                                - curfew
+                                - social distancing
+                            name: social_distancing
+                            polarity: 1
+                            semantic type: event
+                - OntologyNode:
+                    examples:
+                        - drilling
+                        - fracking
+                        - mining
+                    name: mining
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    definition: make less severe, serious, or painful; lessen the gravity
+                    examples:
+                        - alleviate
+                        - counteract
+                        - curtail
+                        - dampen
+                        - deter
+                        - diffuse
+                        - mitigate
+                        - mitigation
+                        - neutralize
+                        - overcome
+                    name: mitigation
+                    polarity: -1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - change
+                        - modify
+                    name: modification
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - drive
+                        - drove
+                        - ignite
+                        - initiate
+                        - invoke
+                        - motivate
+                        - prompt
+                        - spark
+                        - spurred
+                        - trigger
+                    name: motivation
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - nominate
+                        - nomination
+                    name: nomination
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - detect
+                        - observe
+                        - oversee
+                        - sense
+                        - survey
+                        - watch
+                    name: observation
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - outbreak
+                        - outbreaks
+                        - plague
+                        - recent outbreaks
+                    name: outbreak
+                    polarity: -1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - design
+                        - plan
+                        - strategy
+                    name: planning
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    name: population
+                    children:
+                        - OntologyNode:
+                            patterns:
+                                - birth
+                            examples:
+                                - birth
+                            name: birth
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - burial
+                                - casualties
+                                - casualty
+                                - chick mortality
+                                - death
+                                - deaths
+                                - fatalities
+                                - fatality
+                                - infant mortality
+                                - killings
+                                - mortality
+                                - mortality rate
+                                - mortality risks
+                                - murder
+                                - new deaths
+                                - total deaths
+                            name: death
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            name: migrate
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - deport
+                                        - emigrate
+                                        - emigration
+                                        - expel
+                                    name: emigrate
+                                    polarity: 1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - asylum
+                                        - immigrate
+                                        - immigration
+                                        - invade
+                                    name: immigrate
+                                    polarity: 1
+                                    semantic type: event
+                                - OntologyNode:
+                                    examples:
+                                        - flee
+                                        - migrate
+                                        - migration
+                                        - relocate
+                                    name: migrate
+                                    polarity: 1
+                                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - anticipate
+                        - forecast
+                        - predict
+                        - prediction
+                        - project
+                        - projection
+                    name: prediction
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - organize
+                        - plan
+                        - prepare
+                    name: preparation
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    definition: keep something from happening or arising
+                    examples:
+                        - limit
+                        - prevent
+                        - suppress
+                        - thwart
+                    name: prevention
+                    polarity: -1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - cleaning
+                        - grading
+                        - manufacturing
+                        - packing
+                        - processing
+                        - shipping
+                        - sorting
+                        - treatment
+                    name: processing
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    patterns:
+                        - \b([pP]roduction|[yY]ields?)\b
+                    examples:
+                        - create
+                        - produce
+                        - production
+                    name: production
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - ban
+                        - criminalize
+                        - outlaw
+                        - prohibit
+                    name: prohibition
+                    polarity: -1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - administer
+                        - deliver
+                        - distribute
+                        - give
+                        - provide
+                        - supply
+                    name: provision
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - broadcast
+                        - print
+                        - publication
+                        - publish
+                        - release
+                        - reprint
+                        - write
+                    name: publication
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - radicalization
+                    name: radicalization
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - react
+                        - reaction
+                        - respond
+                        - response
+                    name: reaction_or_response
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - forgiveness
+                        - relief
+                    name: relief
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    definition: provide a remedy for; redress or make right; restore by reversing or stopping environmental damage
+                    examples:
+                        - reconcile
+                        - remediate
+                        - resolve
+                        - settle
+                        - solve
+                    name: remediation
+                    polarity: -1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - reconstruct
+                        - repair
+                        - restore
+                    name: repair
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - hens
+                        - laying hens
+                        - reproduce
+                        - reproduction
+                        - rooster
+                    name: reproduction
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    definition: The collection, organization, and analysis of information to increase understanding of a topic or issue.
+                    examples:
+                        - experiment
+                        - observe
+                        - research
+                        - science
+                        - scientific
+                        - study
+                        - survey
+                    name: research
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - conserve
+                        - defend
+                        - guard
+                        - preserve
+                        - protect
+                        - safeguard
+                        - secure
+                        - ward
+                    name: securing
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - choose
+                        - select
+                        - selection
+                    name: selection
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - share
+                        - sharing
+                    name: sharing
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - stabilization
+                        - stabilize
+                    name: stabilization
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - delay
+                        - hamper
+                        - limit
+                        - shorten
+                        - stall
+                        - temper
+                    name: stalling
+                    polarity: -1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - begin
+                        - commence
+                        - initiate
+                        - start
+                    name: start
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - continue
+                        - exist
+                        - remain
+                        - stay
+                    name: stay_or_remain
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - prop up
+                        - shore up
+                        - strengthen
+                    name: strengthening
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - monitor
+                        - surveil
+                    name: surveilance
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - count
+                        - enumerate
+                        - tabulate
+                    name: tabulation
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    name: trade
+                    children:
+                        - OntologyNode:
+                            patterns:
+                                - \bexports?\b
+                            examples:
+                                - export
+                            name: export
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            patterns:
+                                - \bimports?\b
+                            examples:
+                                - import
+                            name: import
+                            polarity: 1
+                            semantic type: event
+                - OntologyNode:
+                    name: training
+                    children:
+                        - OntologyNode:
+                            examples:
+                                - agriculture training
+                                - pest control
+                                - post harvest
+                                - production practices
+                                - weed control
+                            name: agriculture_training
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - financial training
+                            name: financial_training
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            name: humanitarian_training
+                            children:
+                                - OntologyNode:
+                                    patterns:
+                                        - (SPHERE)
+                                    examples:
+                                        - SPHERE
+                                        - emergency preparedness training
+                                        - humanitarian certifications
+                                    name: emergency_preparedness_training
+                                    polarity: 1
+                                    semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - medical training
+                            name: medical_training
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - abilities
+                                - advice
+                                - advisors
+                                - caution
+                                - centres
+                                - certificate
+                                - coordinators
+                                - course
+                                - curricula
+                                - direction
+                                - educate
+                                - exercises
+                                - expertise
+                                - extension services
+                                - guidance
+                                - guideline
+                                - guides
+                                - instructions
+                                - leadership
+                                - leadership positions
+                                - lessons
+                                - manpower
+                                - manual
+                                - manuals
+                                - modules
+                                - oversight
+                                - participants
+                                - phases
+                                - programme
+                                - programs
+                                - qualifications
+                                - regular basis
+                                - skill
+                                - skill assessments
+                                - skills
+                                - staffing
+                                - strategic direction
+                                - supervision
+                                - team members
+                                - technical advice
+                                - technical assistance
+                                - technical capacity
+                                - technical expertise
+                                - technical knowledge
+                                - trainers
+                                - training
+                                - training activities
+                                - training manual
+                                - training materials
+                                - training programmes
+                                - training programs
+                                - training session
+                                - vocational training
+                            name: training
+                            polarity: 1
+                            semantic type: event
+                - OntologyNode:
+                    examples:
+                        - buy
+                        - food transaction
+                        - gift
+                        - oil transaction
+                        - purchase
+                        - repayment
+                        - sale
+                        - sell
+                        - selling
+                        - transaction
+                    name: transaction
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - modernize
+                        - reform
+                        - transform
+                    name: transformation
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - airborne
+                        - community spread
+                        - exposure
+                        - infectious
+                        - spread
+                        - transmission
+                    name: transmission
+                    polarity: -1
+                    semantic type: event
+                - OntologyNode:
+                    name: transportation
+                    children:
+                        - OntologyNode:
+                            examples:
+                                - air travel
+                                - commercial transportation
+                                - public transport
+                            name: commercial_transportation
+                            polarity: 1
+                            semantic type: event
+                        - OntologyNode:
+                            examples:
+                                - commute
+                                - personal transportation
+                                - taxi
+                            name: personal_transportation
+                            polarity: 1
+                            semantic type: event
+                - OntologyNode:
+                    examples:
+                        - journey
+                        - travel
+                        - trip
+                        - visit
+                    name: travel
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - cast ballot
+                        - elect
+                        - vote
+                    name: voting
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - undermine
+                        - weaken
+                    name: weakening
+                    polarity: -1
+                    semantic type: event
+        - OntologyNode:
+            name: property
+            children:
+                - OntologyNode:
+                    examples:
+                        - accountability
+                        - responsibility
+                    name: accountability
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - affordable
+                        - cost-effective
+                        - economical
+                        - reasonably priced
+                    name: affordability
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - aftermath
+                        - fallout
+                        - following
+                        - lingering impact
+                        - result
+                        - trauma
+                        - wake
+                    name: aftermath
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - allegiance
+                        - loyalty
+                    name: allegiance
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - availability
+                    name: availability
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - chronic
+                        - endemic
+                        - longstanding
+                        - perennial
+                        - persistent
+                        - pervasive
+                        - prevalence
+                        - prevalent
+                        - protracted
+                        - rampant
+                        - recurrent
+                        - systemic
+                        - widespread
+                    name: chronic
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    definition: relating to ordinary citizens and their concerns
+                    examples:
+                        - citizen
+                        - civic
+                        - civil
+                    name: civic
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - awareness
+                        - clarity
+                        - common understanding
+                        - insight
+                        - mutual understanding
+                        - public awareness
+                    name: common_understanding
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - condition
+                        - conditions
+                    name: condition
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - absorptive capacity
+                        - adaptive capacity
+                        - capacities
+                        - capacity
+                        - coping capacities
+                        - coping capacity
+                        - coping mechanisms
+                        - core capacities
+                        - institutional capacity
+                        - nets
+                        - organizational capacity
+                        - response capacities
+                        - response capacity
+                        - vulnerability
+                    name: coping_capacities
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - diversity
+                    name: diversity
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - domestic
+                        - internal
+                    name: domestic
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - antibiotic resistance
+                        - antimicrobial resistance
+                        - antimicrobials
+                        - biodefense
+                        - drug resistance
+                        - infectivity
+                        - microbes
+                        - microbial threats
+                        - promoters
+                        - resistance
+                        - resistant pathogens
+                        - transporters
+                    name: drug_resistance
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - efficiency
+                    name: efficiency
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - exotic breeds
+                    name: exotic_breeds
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - equality
+                        - equity
+                        - fairness
+                        - integrity
+                    name: fairness
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - bilateral
+                        - external aid
+                        - foreign
+                        - foreign aid
+                        - multilateral
+                        - overseas
+                    name: foreign
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    name: geographic_resolution
+                    children:
+                        - OntologyNode:
+                            examples:
+                                - global
+                                - world
+                            name: global
+                            polarity: 1
+                            semantic type: property
+                        - OntologyNode:
+                            examples:
+                                - international
+                            name: international
+                            polarity: 1
+                            semantic type: property
+                        - OntologyNode:
+                            examples:
+                                - city
+                                - local
+                                - town
+                            name: local
+                            polarity: 1
+                            semantic type: property
+                        - OntologyNode:
+                            examples:
+                                - nation
+                                - national
+                                - state
+                            name: national
+                            polarity: 1
+                            semantic type: entity
+                        - OntologyNode:
+                            examples:
+                                - kebele
+                                - provincial
+                                - regional
+                                - woreda
+                            name: sub-national
+                            polarity: 1
+                            semantic type: property
+                - OntologyNode:
+                    examples:
+                        - commercial breeds
+                        - crossbred
+                        - crossbred chickens
+                        - crossbreeds
+                        - horro
+                        - hybrid breeds
+                        - hybrids
+                        - improved breed
+                        - improved breeds
+                        - improved chickens
+                        - improved genetics
+                        - improved horro
+                        - improved stock
+                        - kuroiler
+                        - new breeds
+                    name: hybrid_breeds
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - hydroponic
+                    name: hydroponic
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - dangerous
+                        - insecure
+                        - insecurity
+                        - unsafe
+                    name: insecurity
+                    polarity: -1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - instability
+                    name: instability
+                    polarity: -1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - constitutional
+                        - constitutionality
+                        - legal
+                        - legality
+                    name: legality
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - nonutilization
+                    name: nonutilization
+                    polarity: -1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - peaceful
+                    name: peaceful
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - choice
+                        - preference
+                        - preferences
+                        - taste
+                    name: preference
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - action
+                        - contingency planning
+                        - contingency plans
+                        - development goals
+                        - early action
+                        - global strategy
+                        - ipc phases
+                        - planning
+                        - preparedness
+                        - preparedness plans
+                        - resilience plan
+                        - response activities
+                        - response measures
+                        - response plan
+                        - response plans
+                        - strategic plan
+                        - task force
+                        - vulnerability assessment
+                    name: preparedness
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    patterns:
+                        - \b([Cc]osts?|[Pp]rices?)\b
+                    examples:
+                        - additional costs
+                        - capital costs
+                        - cost
+                        - costs
+                        - expenses
+                        - hidden costs
+                        - high costs
+                        - higher costs
+                        - indirect costs
+                        - input costs
+                        - operating costs
+                        - opportunity costs
+                        - price
+                        - recurrent costs
+                        - social costs
+                    name: price_or_cost
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - private
+                    name: private
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - egg productivity
+                        - performance
+                        - poultry meat productivity
+                        - productivity
+                    name: productivity
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - public
+                    name: public
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - feed quality
+                        - quality
+                    name: quality
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - resilience
+                        - resiliency
+                        - robustness
+                    name: resilience
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - land rights
+                        - land tenure
+                        - right to use
+                    name: right_to_use
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - risk
+                    name: risk
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - cycles
+                        - delayed
+                        - historical trends
+                        - inflation
+                        - movements
+                        - patterns
+                        - recent trends
+                        - seasonal
+                        - seasonal changes
+                        - seasonal patterns
+                        - seasonal pressure
+                        - seasonal trends
+                        - seasonal variation
+                        - seasonal variations
+                        - seasonality
+                        - significant changes
+                        - timing
+                        - variations
+                    name: seasonality
+                    polarity: 1
+                    semantic type: event
+                - OntologyNode:
+                    examples:
+                        - safety
+                        - security
+                    name: security
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - social
+                    name: social
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    definition: Being unlikely to move or change.
+                    examples:
+                        - order
+                        - stability
+                    name: stability
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - affinity
+                        - camaraderie
+                        - empathy
+                        - goodwill
+                        - solidarity
+                        - support
+                    name: support
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - agricultural surplus
+                        - egg surplus
+                        - excess
+                        - marketable surplus
+                        - meat surplus
+                        - surplus
+                    name: surplus
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - sustainability
+                        - sustainable
+                    name: sustainable
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - makeshift
+                        - temporary
+                    name: temporary
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - openness
+                        - transparency
+                    name: transparency
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - lack
+                        - paucity
+                        - scant
+                        - scarce
+                        - shortage
+                        - sparse
+                        - unavailability
+                    name: unavailability
+                    polarity: -1
+                    semantic type: property
+                - OntologyNode:
+                    definition: An epistemic situation involving imperfect or unknown information.
+                    examples:
+                        - uncertainty
+                        - volatility
+                    name: uncertainty
+                    polarity: -1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - utilization
+                    name: utilization
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - precarious
+                        - tumult
+                        - tumultuous
+                        - variability
+                        - variable
+                        - volatile
+                        - volatility
+                    name: variability
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - violent
+                    name: violent
+                    polarity: 1
+                    semantic type: property
+                - OntologyNode:
+                    examples:
+                        - fragile
+                        - fragility
+                        - tenuous
+                        - vulnerability
+                        - vulnerable
+                    name: vulnerability
+                    polarity: 1
+                    semantic type: property
 

--- a/CompositionalOntology_metadata.yml
+++ b/CompositionalOntology_metadata.yml
@@ -84,7 +84,8 @@ node:
                             children:
                                 - node:
                                     name: cereals
-                                    definition: A grass cultivated for the edible parts of its grain.
+                                    descriptions:
+                                        - A grass cultivated for the edible parts of its grain.
                                     examples:
                                         - barley
                                         - cereals
@@ -198,7 +199,8 @@ node:
                                     semantic type: entity
                                 - node:
                                     name: vegetables
-                                    definition: vegetable crops and food
+                                    descriptions:
+                                        - vegetable crops and food
                                     examples:
                                         - beets
                                         - cabbage
@@ -275,7 +277,8 @@ node:
                                     semantic type: event
                         - node:
                             name: livestock_nonpoultry
-                            definition: Domesticated animals raised for their labor or to produce commodities such as milk, meat, eggs, fur, leather, or wool.
+                            descriptions:
+                                - Domesticated animals raised for their labor or to produce commodities such as milk, meat, eggs, fur, leather, or wool.
                             examples:
                                 - beef
                                 - bull
@@ -844,7 +847,8 @@ node:
                             children:
                                 - node:
                                     name: drought
-                                    definition: A prolonged shortage in the water supply.
+                                    descriptions:
+                                        - A prolonged shortage in the water supply.
                                     examples:
                                         - drought
                                         - droughts
@@ -937,7 +941,8 @@ node:
                                     semantic type: event
                         - node:
                             name: epidemic
-                            definition: The rapid spread of disease to a large population in a short amount of time.
+                            descriptions:
+                                - The rapid spread of disease to a large population in a short amount of time.
                             examples:
                                 - disease
                                 - epidemic
@@ -2150,7 +2155,8 @@ node:
                             semantic type: entity
                         - node:
                             name: ruling_party
-                            definition: 'note: in Kenya, the ruling party is the Jubilee party'
+                            descriptions:
+                                - 'note: in Kenya, the ruling party is the Jubilee party'
                             examples:
                                 - incumbent
                                 - incumbent government
@@ -2376,7 +2382,8 @@ node:
                                     semantic type: event
                                 - node:
                                     name: weather
-                                    definition: The state of the atmosphere, describing the degree to which it is hot or cold, wet or dry, calm or stormy, clear or cloudy.
+                                    descriptions:
+                                        - The state of the atmosphere, describing the degree to which it is hot or cold, wet or dry, calm or stormy, clear or cloudy.
                                     examples:
                                         - climate variability
                                         - extreme winds
@@ -2396,7 +2403,8 @@ node:
                             children:
                                 - node:
                                     name: fossil_fuels
-                                    definition: Fuels formed from natural processes, containing organic molecules, that release energy in combustion.
+                                    descriptions:
+                                        - Fuels formed from natural processes, containing organic molecules, that release energy in combustion.
                                     examples:
                                         - carbon
                                         - crude oil
@@ -2425,7 +2433,8 @@ node:
                                     semantic type: entity
                                 - node:
                                     name: pasture
-                                    definition: Land used for grazing by domesticated livestock.
+                                    descriptions:
+                                        - Land used for grazing by domesticated livestock.
                                     examples:
                                         - grazing
                                         - pastoral
@@ -2991,7 +3000,8 @@ node:
                             semantic type: entity
                         - node:
                             name: sanction
-                            definition: A restriction on trade, or measures by a country on a state or individual intended to elicit a change in their behavior.
+                            descriptions:
+                                - A restriction on trade, or measures by a country on a state or individual intended to elicit a change in their behavior.
                             examples:
                                 - sanction
                             polarity: -1
@@ -3457,7 +3467,8 @@ node:
                             semantic type: event
                         - node:
                             name: vector
-                            definition: An agent that carries or transmits an infectious pathogen into another living organism.
+                            descriptions:
+                                - An agent that carries or transmits an infectious pathogen into another living organism.
                             examples:
                                 - excrement
                                 - mosquitos
@@ -4356,7 +4367,8 @@ node:
             children:
                 - node:
                     name: access
-                    definition: The ability or right to approach, enter, exit, make use of, or communicate with something.
+                    descriptions:
+                        - The ability or right to approach, enter, exit, make use of, or communicate with something.
                     examples:
                         - access
                     polarity: 1
@@ -4803,7 +4815,8 @@ node:
                             semantic type: event
                         - node:
                             name: exploit
-                            definition: To make use of (sometimes unfairly) to one's own advantage.
+                            descriptions:
+                                - To make use of (sometimes unfairly) to one's own advantage.
                             examples:
                                 - cheat
                                 - coerce
@@ -5158,7 +5171,8 @@ node:
                             semantic type: event
                         - node:
                             name: irrigation
-                            definition: The process of applying controlled amounts of water to plants.
+                            descriptions:
+                                - The process of applying controlled amounts of water to plants.
                             examples:
                                 - irrigate
                                 - irrigating
@@ -5467,7 +5481,8 @@ node:
                     semantic type: event
                 - node:
                     name: mitigation
-                    definition: make less severe, serious, or painful; lessen the gravity
+                    descriptions:
+                        - make less severe, serious, or painful; lessen the gravity
                     examples:
                         - alleviate
                         - counteract
@@ -5621,7 +5636,8 @@ node:
                     semantic type: event
                 - node:
                     name: prevention
-                    definition: keep something from happening or arising
+                    descriptions:
+                        - keep something from happening or arising
                     examples:
                         - limit
                         - prevent
@@ -5708,7 +5724,8 @@ node:
                     semantic type: event
                 - node:
                     name: remediation
-                    definition: provide a remedy for; redress or make right; restore by reversing or stopping environmental damage
+                    descriptions:
+                        - provide a remedy for; redress or make right; restore by reversing or stopping environmental damage
                     examples:
                         - reconcile
                         - remediate
@@ -5737,7 +5754,8 @@ node:
                     semantic type: event
                 - node:
                     name: research
-                    definition: The collection, organization, and analysis of information to increase understanding of a topic or issue.
+                    descriptions:
+                        - The collection, organization, and analysis of information to increase understanding of a topic or issue.
                     examples:
                         - experiment
                         - observe
@@ -6091,7 +6109,8 @@ node:
                     semantic type: property
                 - node:
                     name: civic
-                    definition: relating to ordinary citizens and their concerns
+                    descriptions:
+                        - relating to ordinary citizens and their concerns
                     examples:
                         - citizen
                         - civic
@@ -6442,7 +6461,8 @@ node:
                     semantic type: property
                 - node:
                     name: stability
-                    definition: Being unlikely to move or change.
+                    descriptions:
+                        - Being unlikely to move or change.
                     examples:
                         - order
                         - stability
@@ -6505,7 +6525,8 @@ node:
                     semantic type: property
                 - node:
                     name: uncertainty
-                    definition: An epistemic situation involving imperfect or unknown information.
+                    descriptions:
+                        - An epistemic situation involving imperfect or unknown information.
                     examples:
                         - uncertainty
                         - volatility

--- a/wm_flat_metadata.yml
+++ b/wm_flat_metadata.yml
@@ -3,28 +3,28 @@
 #  - we don't attempt to differentiate "event" and "entities" but rather trying to put all causal factors into "causal_factor"
 #  - use coarse-grained concepts "causal_factor", "entity" (where the causal factor is located, who and what artifacts are involved in a causal factor), "time", and "indicator_and_reported_property" as the top level concepts.
 # - allow multiple inheritance ("economic_crisis" is a child to both "economic_and_commerce" and "crisis_and_disaster"). Concepts under "intervention" and "condition" will overlap with other categories
-OntologyNode:
+node:
     name: wm
     children:
-        - OntologyNode:
+        - node:
             name: concept
             children:
-                - OntologyNode:
+                - node:
                     name: causal_factor
                     children:
-                        - OntologyNode:
+                        - node:
                             name: interventions
                             children:
-                                - OntologyNode:
+                                - node:
                                     name: provide
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             name: agriculture_inputs
                                             children:
-                                                - OntologyNode:
+                                                - node:
                                                     name: livestock_production_inputs
                                                     children:
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - livestock feed
                                                                 - hay
@@ -34,7 +34,7 @@ OntologyNode:
                                                                 - soybean hulls
                                                             name: livestock_feed
                                                             polarity: 1
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - veterinary services medicine
                                                                 - animal birthing
@@ -42,15 +42,15 @@ OntologyNode:
                                                                 - livestock vaccination
                                                             name: veterinary_services
                                                             polarity: 1
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - livestock watering
                                                             name: livestock_watering
                                                             polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     name: crop_production_equipment
                                                     children:
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - farm equipment
                                                                 - machinery
@@ -61,7 +61,7 @@ OntologyNode:
                                                                 - winnower
                                                             name: farm_equipment
                                                             polarity: 1
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - harvesting equipment
                                                                 - baskets
@@ -70,16 +70,16 @@ OntologyNode:
                                                                 - clippers
                                                             name: harvesting_equipment
                                                             polarity: 1
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - seed
                                                                 - planting
                                                             name: seed
                                                             polarity: 1
-                                                        - OntologyNode:
+                                                        - node:
                                                             name: irrigation_equipment
                                                             children:
-                                                                - OntologyNode:
+                                                                - node:
                                                                     examples:
                                                                         - water source
                                                                         - wells
@@ -88,7 +88,7 @@ OntologyNode:
                                                                         - canal
                                                                     name: water_source
                                                                     polarity: 1
-                                                                - OntologyNode:
+                                                                - node:
                                                                     examples:
                                                                         - water pumps
                                                                         - treadle
@@ -96,17 +96,17 @@ OntologyNode:
                                                                         - small scale irrigation pump
                                                                     name: pumps
                                                                     polarity: 1
-                                                                - OntologyNode:
+                                                                - node:
                                                                     examples:
                                                                         - field irrigation
                                                                         - drip
                                                                         - sprinklers
                                                                     name: field_irrigation
                                                                     polarity: 1
-                                                        - OntologyNode:
+                                                        - node:
                                                             name: soil_inputs
                                                             children:
-                                                                - OntologyNode:
+                                                                - node:
                                                                     examples:
                                                                         - fertilizer
                                                                         - DAP
@@ -118,7 +118,7 @@ OntologyNode:
                                                                         - phosphorous
                                                                     name: fertilizer
                                                                     polarity: 1
-                                                                - OntologyNode:
+                                                                - node:
                                                                     examples:
                                                                         - fertilizer subsidy
                                                                         - fertilizer voucher
@@ -127,10 +127,10 @@ OntologyNode:
                                                                         - fertilizer coupon
                                                                     name: fertilizer_subsidy
                                                                     polarity: 1
-                                                        - OntologyNode:
+                                                        - node:
                                                             name: weed_pest_control
                                                             children:
-                                                                - OntologyNode:
+                                                                - node:
                                                                     examples:
                                                                         - biological pest weed control
                                                                         - crop rotation
@@ -140,7 +140,7 @@ OntologyNode:
                                                                         - companion planting
                                                                     name: biological
                                                                     polarity: 1
-                                                                - OntologyNode:
+                                                                - node:
                                                                     patterns:
                                                                         - \b(DDT|dicamba|round-up)\b
                                                                     examples:
@@ -151,7 +151,7 @@ OntologyNode:
                                                                         - DDT
                                                                     name: chemical
                                                                     polarity: 1
-                                                                - OntologyNode:
+                                                                - node:
                                                                     examples:
                                                                         - organic pest weed control
                                                                         - vinegar
@@ -159,10 +159,10 @@ OntologyNode:
                                                                         - neem oil
                                                                     name: organic
                                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     name: post_harvest_inputs
                                                     children:
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - harvest processing equipment
                                                                 - thresher
@@ -175,7 +175,7 @@ OntologyNode:
                                                                 - harvest drier racks
                                                             name: processing_equipment
                                                             polarity: 1
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - harvest packaging
                                                                 - packing lines
@@ -183,7 +183,7 @@ OntologyNode:
                                                                 - packaging material
                                                             name: packaging
                                                             polarity: 1
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - warehousing
                                                                 - warehouse receipt system
@@ -191,10 +191,10 @@ OntologyNode:
                                                                 - storage
                                                             name: warehousing
                                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             name: information_services
                                             children:
-                                                - OntologyNode:
+                                                - node:
                                                     patterns:
                                                         - \b(IPC|FEWS|VAM)\b
                                                         - \bearly\s+warning\s+system\b
@@ -212,20 +212,20 @@ OntologyNode:
                                                         - VAM
                                                     name: surveillance_system
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - weather monitoring
                                                     name: weather_monitoring
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - price monitoring
                                                     name: price_monitoring
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     name: human_rights_monitoring
                                                     children:
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - victims
                                                                 - children victims
@@ -235,7 +235,7 @@ OntologyNode:
                                                                 - ethnic minorities
                                                             name: victims
                                                             polarity: 1
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - perpetrators
                                                                 - militias
@@ -244,7 +244,7 @@ OntologyNode:
                                                                 - non state actors
                                                             name: perpetrators
                                                             polarity: 1
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - violations
                                                                 - human rights violations crimes
@@ -253,10 +253,10 @@ OntologyNode:
                                                                 - GBV
                                                             name: violations
                                                             polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     name: statistics
                                                     children:
-                                                        - OntologyNode:
+                                                        - node:
                                                             patterns:
                                                                 - \b(census|AgSS|CFSVA)\b
                                                             examples:
@@ -270,10 +270,10 @@ OntologyNode:
                                                                 - agricultural sample survey
                                                             name: national_survey
                                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             name: livelihood_support
                                             children:
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - food aid
                                                         - food for work
@@ -284,7 +284,7 @@ OntologyNode:
                                                         - school feeding
                                                     name: food_aid
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - nutrition support
                                                         - food fortification
@@ -294,13 +294,13 @@ OntologyNode:
                                                         - supplementary feeding
                                                     name: nutrition_support
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - water
                                                         - water trucking
                                                     name: water
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - financial assistance
                                                         - cash
@@ -313,7 +313,7 @@ OntologyNode:
                                                         - remittances
                                                     name: financial_assistance
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - livelihood assets
                                                         - fishing nets
@@ -325,20 +325,20 @@ OntologyNode:
                                                         - cart
                                                     name: livelihood_assets
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     name: humanitarian_nonfood_items
                                                     children:
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - shelter
                                                                 - tents
                                                                 - shelter kits
                                                             name: shelter
                                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             name: medical_inputs
                                             children:
-                                                - OntologyNode:
+                                                - node:
                                                     patterns:
                                                         - \b(immuniz(ations?|e))\b
                                                     examples:
@@ -352,7 +352,7 @@ OntologyNode:
                                                         - yellow fever
                                                     name: vaccine
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - medical treatment
                                                         - anti retroviral treatment
@@ -367,7 +367,7 @@ OntologyNode:
                                                         - trauma and post operative rehabilitation
                                                     name: medical_treatment
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - prevention
                                                         - insecticide treated bednets
@@ -377,7 +377,7 @@ OntologyNode:
                                                         - well-visit
                                                     name: prevention
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - psychological
                                                         - therapy
@@ -386,7 +386,7 @@ OntologyNode:
                                                         - therapist counselor
                                                     name: psychological
                                                     polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - sanitation and hygiene input
                                                 - desludging
@@ -398,16 +398,16 @@ OntologyNode:
                                                 - piped water supply treatment
                                             name: sanitation_and_hygiene_inputs
                                             polarity: 1
-                                - OntologyNode:
+                                - node:
                                     name: build
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             name: agriculture_infrastructure
                                             children:
-                                                - OntologyNode:
+                                                - node:
                                                     name: livestock_production_infrastructure
                                                     children:
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - enclosure
                                                                 - barn
@@ -418,10 +418,10 @@ OntologyNode:
                                                                 - coop
                                                             name: livestock_shelter # enclosure, barn, pasture, etc
                                                             polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     name: crop_production_infrastructure
                                                     children:
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - canal
                                                                 - reservoir
@@ -430,7 +430,7 @@ OntologyNode:
                                                                 - irrigation infrastructure
                                                             name: irrigation_infrastructure # canal, reservoir, water_tower
                                                             polarity: 1
-                                                        - OntologyNode:
+                                                        - node:
                                                             patterns:
                                                                 - \bextension\s+offices?
                                                             examples:
@@ -439,7 +439,7 @@ OntologyNode:
                                                                 - extension office
                                                             name: extension_offices # farmer_training_centers, demonstration plots, etc
                                                             polarity: 1
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - nursery
                                                                 - plant nursery
@@ -449,7 +449,7 @@ OntologyNode:
                                                                 - hothouse
                                                             name: greenhouse # nursery, high_tunnel, etc.
                                                             polarity: 1
-                                                        - OntologyNode:
+                                                        - node:
                                                             patterns:
                                                                 - \b(tower|bunker|stave|grain)\b\s(silo)
                                                             examples:
@@ -464,7 +464,7 @@ OntologyNode:
                                                                 - post-harvest
                                                             name: post_harvest_infrastructure # on-farm_processing_facility, silos, cooperative_processing, storage, etc.
                                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - factory
                                                 - industrial park
@@ -474,7 +474,7 @@ OntologyNode:
                                                 - trade infrastructure
                                             name: trade_infrastructure # factory, industrial_park, storage_facilities, warehouse, processing_facilities, etc.
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - community center
                                                 - classroom
@@ -485,7 +485,7 @@ OntologyNode:
                                                 - school infrastructure
                                             name: educational_infrastructure # community_centers, child_friendly_learning_spaces, school_rehabilitation, gender_specific_bathrooms, etc.
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - permanent house
                                                 - temporary housing
@@ -498,7 +498,7 @@ OntologyNode:
                                                 - shelter
                                             name: shelter_housing # permanent_house, temporary_housing, refugee_camp, housing_provision, leasing_or_rental_services, temporary_communal_settlement, etc.
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             patterns:
                                                 - \b(WASH)\binfrastructure
                                             examples:
@@ -512,7 +512,7 @@ OntologyNode:
                                                 - WASH infrastructure
                                             name: WASH_infrastructure # sanitation facilities, latrines, washing_and_bathing_facilities, temporary_water_points, boreholes, permanent_water_points, borehole_repair, etc.
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - hospital
                                                 - mobile clinic
@@ -524,7 +524,7 @@ OntologyNode:
                                                 - medical infrastructure
                                             name: medical_infrastructure # hospitals, mobile clinics, field_hospitals, emergency treatment centers, medical supply chain facilities, etc.
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             patterns:
                                                 - \b(road|bridge|rail)\s(repair)
                                             examples:
@@ -537,7 +537,7 @@ OntologyNode:
                                                 - transportation infrastructure
                                             name: transportation_infrastructure # bridge, repair, all_weather_roads, railway_lines, temporary_roads, road_rehabilitation
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - internet access service
                                                 - cell-phone tower
@@ -549,7 +549,7 @@ OntologyNode:
                                                 - communication infrastructure
                                             name: communication_infrastructure # cell-phone_towers, landlines, etc
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - dam
                                                 - electricity grid
@@ -563,16 +563,16 @@ OntologyNode:
                                                 - energy infrastructure
                                             name: energy_infrastructure # dams, electricity_grids, micro-grids, solar_panels, wind_turbines, wind_farms, solar_farms, etc.
                                             polarity: 1
-                                - OntologyNode:
+                                - node:
                                     name: train
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             name: agriculture_training
                                             children:
-                                                - OntologyNode:
+                                                - node:
                                                     name: production_practices
                                                     children:
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - cover cropping
                                                                 - composting
@@ -580,7 +580,7 @@ OntologyNode:
                                                                 - training
                                                             name: planting_training # crop_spacing, planting_times, seed_depth, watering, crop_rotation, cover_cropping, composting, low_till, no_till, perennial_planting, Conservation_agriculture
                                                             polarity: 1
-                                                        - OntologyNode:
+                                                        - node:
                                                             patterns:
                                                                 - (\bIPM\b)(\s(practices))?
                                                             examples:
@@ -590,7 +590,7 @@ OntologyNode:
                                                                 - weed control
                                                             name: pest_weed_control # IPM_practices (integrated pest management), etc
                                                             polarity: 1
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - training storage
                                                                 - training processing
@@ -603,7 +603,7 @@ OntologyNode:
                                                                 - post-harvest practices
                                                             name: post_harvest_practices # storage, processing, packaging, safety_and_hygiene, certifications, ISO, FDA, work_place_safety, etc.
                                                             polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     patterns:
                                                         - (\bNM[AS]\b)\s(reports?)
                                                     examples:
@@ -613,10 +613,10 @@ OntologyNode:
                                                         - agriculture information
                                                     name: agriculture_information # digital_extension, famers_almanac, mobile_extension, SMS reminders,  Weather_information,  NMA_reports (national met agency), broadcast_weather_reports,
                                                     polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             name: medical_training
                                             children:
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - medical training
                                                         - assessment of health facilities
@@ -626,18 +626,18 @@ OntologyNode:
                                                         - medical capacity assessment
                                                     name: assessment_and_triage_of_health_facilities
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - capacity building of medical staff
                                                         - medical capacity building
                                                     name: capacity_building_of_medical_staff
                                                     polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - human rights training
                                             name: human_rights_training
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - provision of credit
                                                 - training for income generation
@@ -646,7 +646,7 @@ OntologyNode:
                                                 - financial management
                                             name: financial_management # provision_of_credit_and_training_for_income_generation
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - provision of non-formal education
                                                 - training community sourced temporary teachers
@@ -655,7 +655,7 @@ OntologyNode:
                                                 - training education capacity building
                                             name: education_systems #  provision_of_non_formal_education, community_sourced_temporary_teachers
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - behavior change campaign
                                                 - behaviour change campaign
@@ -667,21 +667,21 @@ OntologyNode:
                                                 - public health campaigns
                                             name: public_health_campaigns # behaviour change, campaigns, public information, hygiene_promotion, information_campaign, health_promoters,
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - explosive hazards campaign
                                                 - public safety campaigns
                                             name: public_safety_campaigns # explosive_hazards
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             name: emergency_preparedness_training
                                             children:
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - surveillance system strengthening
                                                     name: surveillance_system_strengthening
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - SPHERE
                                                         - core standards
@@ -689,10 +689,10 @@ OntologyNode:
                                                         - humanitarian certifications
                                                     name: humanitarian_certifications # SPHERE, core_standards, humanitarian_charter, etc.
                                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     name: secure
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - agricultural assets
                                                 - cattle raid
@@ -707,10 +707,10 @@ OntologyNode:
                                                 - secure livelihood
                                             name: livelihood_protections #  agricultural assets, cattle_raids, supply chains,
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             name: community_security
                                             children:
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - mine clearance
                                                         - demining
@@ -719,7 +719,7 @@ OntologyNode:
                                                         - neutralize land mines
                                                     name: mine_clearance
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - temporary policing services
                                                         - temporary police
@@ -727,7 +727,7 @@ OntologyNode:
                                                         - security escort
                                                     name: temporary_policing_services
                                                     polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             patterns:
                                                 - peace\s+(building|talks)
                                                 - conflict\s+resolution
@@ -742,7 +742,7 @@ OntologyNode:
                                                 - conflict resolution
                                             name: conflict_resolution # conflict_mediation, political_dialogue, disarmament, demobilization, reintegration, family_reunification, rehabilitation_of_child_soldier
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - water rights
                                                 - land rights
@@ -757,7 +757,7 @@ OntologyNode:
                                                 - secure natural resources
                                             name: secure_natural_resources # Water_rights, Land_rights, land_deeds, Biotechnology, etc.
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             patterns:
                                                 - \bUNESCO\b\sworld\sheritage\ssite
                                             examples:
@@ -766,17 +766,17 @@ OntologyNode:
                                                 - cultural resources protections
                                             name: cultural_resources # landmark_designation, world_heritage_status, etc.
                                             polarity: 1
-                                - OntologyNode:
+                                - node:
                                     name: legislate
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - subsidize
                                                 - subsidies
                                                 - subsidy
                                             name: subsidize
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - tax
                                                 - taxation
@@ -786,7 +786,7 @@ OntologyNode:
                                                 - tariff
                                             name: tax
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - control prices
                                                 - price control
@@ -796,13 +796,13 @@ OntologyNode:
                                                 - price floor
                                             name: control_prices
                                             polarity: 1
-                        - OntologyNode:
+                        - node:
                             name: environmental
                             children:
-                                - OntologyNode:
+                                - node:
                                     name: meteorologic
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - weather
                                                 - weather systems
@@ -816,17 +816,17 @@ OntologyNode:
                                                 - humid
                                             name: weather
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - climate
                                                 - tropical
                                                 - equatorial
                                             name: climate
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             name: precipitation
                                             children:
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - rainfall
                                                         - precipitation
@@ -834,14 +834,14 @@ OntologyNode:
                                                         - rain
                                                     name: rainfall
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - storm
                                                         - seasonal monsoon
                                                         - extreme weather
                                                     name: storm
                                                     polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - temperature
                                                 - cooler
@@ -855,18 +855,18 @@ OntologyNode:
                                                 - warming
                                             name: temperature # temperature of ...
                                             polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - environment
                                     name: environment
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - climate change mitigation
                                         - climate change adaptation
                                     name: climate_change_mitigation
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - conservation
                                         - sustainable use
@@ -878,7 +878,7 @@ OntologyNode:
                                         - overexploitation
                                     name: resource_management
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - afforestation
                                         - agroforestry
@@ -888,10 +888,10 @@ OntologyNode:
                                         - logging
                                     name: forestry
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     name: natural_resources
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - water
                                                 - sea
@@ -907,13 +907,13 @@ OntologyNode:
                                                 - reservoir
                                             name: water_bodies
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - land availability
                                                 - availability of cropland
                                             name: land_availability
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - fossil fuels
                                                 - coal
@@ -921,14 +921,14 @@ OntologyNode:
                                                 - natural gas
                                             name: fossil_fuels
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - soil
                                                 - soil quality
                                                 - leaching into the soil
                                             name: soil
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - pastoral conditions
                                                 - pasture conditions
@@ -937,17 +937,17 @@ OntologyNode:
                                                 - grazing conditions
                                             name: pasture
                                             polarity: 1
-                                - OntologyNode:
+                                - node:
                                     name: pollution
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - pollution
                                                 - greenhouse gas emission
                                                 - ghg emission
                                             name: air_pollution
                                             polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - contaminant
                                                 - contamination
@@ -960,20 +960,20 @@ OntologyNode:
                                                 - acidification
                                             name: land_pollution
                                             polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - deforestation
                                                 - desertification
                                                 - climate change
                                             name: climate_change
                                             polarity: -1
-                        - OntologyNode:
+                        - node:
                             name: crisis_and_disaster
                             children:
-                                - OntologyNode:
+                                - node:
                                     name: health
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - disease outbreak
                                                 - global pandemic
@@ -981,10 +981,10 @@ OntologyNode:
                                                 - epidemic
                                             name: pandemic
                                             polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             name: mitigation
                                             children:
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - sanitation
                                                         - hygiene materials
@@ -992,14 +992,14 @@ OntologyNode:
                                                         - wash hands
                                                     name: sanitation
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     patterns:
                                                         - (contact tracing)
                                                     examples:
                                                         - contact tracing
                                                     name: contact_tracing
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     patterns:
                                                         - (quarantin|shelter[- ]in[- ]place)
                                                     examples:
@@ -1009,21 +1009,21 @@ OntologyNode:
                                                         - restrict movements
                                                     name: quarantine
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     patterns:
                                                         - (social distancing)
                                                     examples:
                                                         - social distancing
                                                     name: social_distancing
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - masks
                                                         - mask requirements
                                                         - wearing face coverings
                                                     name: masks
                                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - famine
                                         - hunger
@@ -1035,7 +1035,7 @@ OntologyNode:
                                         - acute malnutrition
                                     name: famine
                                     polarity: -1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - crisis
                                         - crises
@@ -1044,35 +1044,35 @@ OntologyNode:
                                         - catastrophe
                                     name: crisis
                                     polarity: -1
-                                - OntologyNode:
+                                - node:
                                     name: economic
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - economic crisis
                                                 - financial crisis
                                                 - economic volatility
                                             name: economic_crisis
                                             polarity: -1
-                                - OntologyNode:
+                                - node:
                                     name: environmental_disasters
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - crop failure
                                                 - loss of crops
                                                 - decimated crop yields
                                             name: crop_failure
                                             polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - insect infestation
                                             name: insect_infestation
                                             polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             name: natural_disaster
                                             children:
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - flood
                                                         - floods
@@ -1080,37 +1080,37 @@ OntologyNode:
                                                         - flash flood
                                                     name: flooding
                                                     polarity: -1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - avalanche
                                                     name: avalanche
                                                     polarity: -1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - wildfire
                                                     name: wildfire
                                                     polarity: -1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - volcanic eruption
                                                     name: volcanic_eruption
                                                     polarity: -1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - drought
                                                         - droughts
                                                         - low rainfall
                                                     name: drought
                                                     polarity: -1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - earthquake
                                                     name: earthquake
                                                     polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             name: weather_issue
                                             children:
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - cold temperature
                                                         - frigid conditions
@@ -1120,7 +1120,7 @@ OntologyNode:
                                                         - state of emergency due to cold weather
                                                     name: cold_temperature
                                                     polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - fire
                                                 - blaze
@@ -1128,27 +1128,27 @@ OntologyNode:
                                                 - burned
                                             name: fire # what is on fire?
                                             polarity: -1
-                        - OntologyNode:
+                        - node:
                             name: economic_and_commerce
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - poverty
                                         - poor
                                     name: poverty
                                     polarity: -1
-                                - OntologyNode:
+                                - node:
                                     name: economic_activity
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             name: livelihood
                                             children:
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - farming
                                                     name: farming
                                                     polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - currency
                                                 - dollar
@@ -1159,13 +1159,13 @@ OntologyNode:
                                                 - foreign exchange
                                             name: currency
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             name: cross_border_trade
                                             children:
-                                                - OntologyNode:
+                                                - node:
                                                     name: import
                                                     children:
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - imported foods
                                                                 - crop imports
@@ -1176,10 +1176,10 @@ OntologyNode:
                                                                 - food trade between countries
                                                             name: food_import # thing imported
                                                             polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     name: export
                                                     children:
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - crop exports
                                                                 - food exports
@@ -1190,10 +1190,10 @@ OntologyNode:
                                                                 - food trade between countries
                                                             name: food_export # thing exported
                                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             name: market
                                             children:
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - labor market
                                                         - labour market
@@ -1204,7 +1204,7 @@ OntologyNode:
                                                         - find work
                                                     name: labor_market
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - fuel
                                                         - biofuel
@@ -1220,10 +1220,10 @@ OntologyNode:
                                                         - oil production
                                                     name: fuel
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     name: price_or_cost
                                                     children:
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - food price
                                                                 - food prices
@@ -1241,7 +1241,7 @@ OntologyNode:
                                                                 - grain cost
                                                             name: food_price
                                                             polarity: 1
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - bamboo prices
                                                                 - banana prices
@@ -1289,30 +1289,30 @@ OntologyNode:
                                                                 - white maize prices
                                                             name: crop_price
                                                             polarity: 1
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - oil price
                                                                 - cost of crude oil
                                                             name: oil_price
                                                             polarity: 1
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - cost of living
                                                                 - rent
                                                                 - housing cost
                                                             name: cost_of_living
                                                             polarity: 1
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - cost of transportation
                                                                 - rising transit costs
                                                                 - fuel prices
                                                             name: cost_of_transportation
                                                             polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     name: revenue
                                                     children:
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - household income
                                                                 - take home pay
@@ -1320,30 +1320,30 @@ OntologyNode:
                                                                 - compensation
                                                             name: household_income
                                                             polarity: 1
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - farmer income
                                                                 - seasonal income
                                                             name: farmer_income
                                                             polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - budget
                                                         - budgetary constraints
                                                         - fiscal deficits
                                                     name: budget
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - assets
                                                         - property
                                                         - land assets
                                                     name: assets
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     name: supply
                                                     children:
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - food supply
                                                                 - market supply of crops
@@ -1352,20 +1352,20 @@ OntologyNode:
                                                                 - supplies of food crops
                                                             name: food_supply
                                                             polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     name: demand
                                                     children:
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - food demand
                                                                 - maize demand
                                                                 - market demand for crops
                                                             name: food_demand
                                                             polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     name: transaction
                                                     children:
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - oil transaction
                                                                 - purchasing crude oil
@@ -1373,12 +1373,12 @@ OntologyNode:
                                                                 - selling barrels
                                                             name: oil_transaction
                                                             polarity: 1
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - purchasing food
                                                             name: food_purchase
                                                             polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - depreciation
                                                         - depreciating
@@ -1386,21 +1386,21 @@ OntologyNode:
                                                         - decreased in value
                                                     name: depreciation
                                                     polarity: -1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - inflation
                                                         - hyperinflation
                                                         - inflationary pressure
                                                     name: inflation
                                                     polarity: -1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - currency devaluation
                                                         - devaluate
                                                         - currency devalued
                                                     name: currency_devaluation
                                                     polarity: -1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - food stocks
                                                         - food reserves
@@ -1411,7 +1411,7 @@ OntologyNode:
                                                         - price stabilization reserves
                                                     name: food_stocks
                                                     polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - business competition
                                                 - competitors
@@ -1421,7 +1421,7 @@ OntologyNode:
                                                 - market pressure
                                             name: competition # between? about?
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - development
                                                 - economic development
@@ -1429,29 +1429,29 @@ OntologyNode:
                                                 - agricultural development
                                             name: development # being developed
                                             polarity: 1
-                        - OntologyNode:
+                        - node:
                             name: research_development
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - novel new technology
                                         - research innovation
                                         - breakthrough technology
                                     name: technology_and_innovation
                                     polarity: 1
-                        - OntologyNode:
+                        - node:
                             name: social_and_political
                             children:
-                                - OntologyNode:
+                                - node:
                                     name: communication
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - planning
                                                 - develop plans
                                             name: planning
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - discussion
                                                 - debate
@@ -1460,7 +1460,7 @@ OntologyNode:
                                                 - dialogue
                                             name: discussion_debate
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - collaboration
                                                 - collaborate
@@ -1470,39 +1470,39 @@ OntologyNode:
                                                 - consortium
                                             name: collaboration
                                             polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - basic services
                                         - primary services
                                         - essential services
                                     name: basic_services
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     name: population_group
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - population density
                                                 - local population
                                             name: population_density
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - depopulation
                                                 - de-population
                                             name: de-population
                                             polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - overcrowding
                                                 - over-crowding
                                                 - population density
                                             name: overcrowding
                                             polarity: -1
-                                - OntologyNode:
+                                - node:
                                     name: educational
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - literacy
                                                 - education
@@ -1514,7 +1514,7 @@ OntologyNode:
                                                 - access to education
                                             name: education
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - educational materials
                                                 - reading materials
@@ -1523,16 +1523,16 @@ OntologyNode:
                                                 - school supplies
                                             name: educational_materials
                                             polarity: 1
-                                - OntologyNode:
+                                - node:
                                     name: government
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - census
                                                 - survey
                                             name: census
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - regulation
                                                 - governance
@@ -1543,7 +1543,7 @@ OntologyNode:
                                                 - policies
                                             name: regulation # topic
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - tax duty
                                                 - taxes
@@ -1554,10 +1554,10 @@ OntologyNode:
                                                 - excise
                                             name: tax_duty
                                             polarity: 1
-                                - OntologyNode:
+                                - node:
                                     name: political
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - political instability
                                                 - power struggle
@@ -1566,7 +1566,7 @@ OntologyNode:
                                                 - unrest
                                             name: political_instability
                                             polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - corruption
                                                 - fraud
@@ -1576,14 +1576,14 @@ OntologyNode:
                                                 - nepotism
                                             name: corruption
                                             polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - independence
                                                 - self-rule
                                                 - political independence
                                             name: independence
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - sanction
                                                 - economic sanctions
@@ -1591,10 +1591,10 @@ OntologyNode:
                                                 - sanctioned
                                             name: sanction
                                             polarity: -1
-                                - OntologyNode:
+                                - node:
                                     name: migration
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - migration
                                                 - displacement
@@ -1614,7 +1614,7 @@ OntologyNode:
                                                 - human displacement
                                             name: human_migration
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - hosting IDPs
                                                 - internal displacement
@@ -1623,7 +1623,7 @@ OntologyNode:
                                                 - host migrants
                                             name: hosting_idps
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - emigration
                                                 - leaving
@@ -1635,7 +1635,7 @@ OntologyNode:
                                                 - refugees from countries
                                             name: emigration
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - arrival
                                                 - arrivals
@@ -1647,29 +1647,29 @@ OntologyNode:
                                                 - new refugees
                                             name: immigration
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - returnee
                                                 - return to homeland
                                                 - returned to countries
                                             name: migration_returnees
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - seasonal migration
                                                 - cyclic migration
                                                 - migrant
                                             name: seasonal_migration
                                             polarity: 1
-                                - OntologyNode:
+                                - node:
                                     name: threat
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - exploitation
                                             name: exploitation
                                             polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - insecurity
                                                 - instability
@@ -1678,15 +1678,15 @@ OntologyNode:
                                                 - dangerous
                                             name: physical_insecurity
                                             polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - disarmament
                                             name: disarmament
                                             polarity: 1
-                                - OntologyNode:
+                                - node:
                                     name: criminal
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - crime
                                                 - crimes
@@ -1708,7 +1708,7 @@ OntologyNode:
                                                 - illegal
                                             name: crime
                                             polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - child abductions
                                                 - abduction
@@ -1718,10 +1718,10 @@ OntologyNode:
                                                 - kidnapped
                                             name: abduction
                                             polarity: -1
-                                - OntologyNode:
+                                - node:
                                     name: conflict
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - political tension
                                                 - political tensions
@@ -1735,7 +1735,7 @@ OntologyNode:
                                                 - threatening
                                             name: tension
                                             polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - conflict
                                                 - war
@@ -1761,7 +1761,7 @@ OntologyNode:
                                                 - army mobilization
                                             name: hostility
                                             polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - civil unrest
                                                 - social unrest
@@ -1778,7 +1778,7 @@ OntologyNode:
                                                 - riot
                                             name: demonstrate
                                             polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - bombard
                                                 - genocide
@@ -1802,7 +1802,7 @@ OntologyNode:
                                                 - the outbreak of war
                                             name: war
                                             polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - bombard
                                                 - genocide
@@ -1826,7 +1826,7 @@ OntologyNode:
                                                 - psychological warfare
                                             name: attack
                                             polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - bombard
                                                 - attack
@@ -1837,7 +1837,7 @@ OntologyNode:
                                                 - explosion
                                             name: strike
                                             polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - terrorism
                                                 - insurgency
@@ -1847,7 +1847,7 @@ OntologyNode:
                                                 - bomb threat
                                             name: terrorism
                                             polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - cattle raid
                                                 - livestock raid
@@ -1855,10 +1855,10 @@ OntologyNode:
                                                 - cattle raiding
                                             name: livestock_raid
                                             polarity: -1
-                        - OntologyNode:
+                        - node:
                             name: movement
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - transport
                                         - transporting
@@ -1866,48 +1866,48 @@ OntologyNode:
                                         - delivery
                                     name: transport
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - evacuate humanitarian workers
                                         - evacuated aid personnel
                                         - evacuating humanitarian
                                     name: evacuate_humanitarian_workers
                                     polarity: -1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - animal migration
                                         - livestock migration
                                     name: animal_migration
                                     polarity: 1
-                        - OntologyNode:
+                        - node:
                             name: agriculture
                             children:
-                                - OntologyNode:
+                                - node:
                                     name: pests
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             name: locust_related
                                             children:
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - locust eggs
                                                     name: locust_eggs
                                                     polarity: -1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - locust breeding
                                                         - breeding area locust
                                                     name: locust_breeding
                                                     polarity: -1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - locust hatching
                                                     name: locust_hatching
                                                     polarity: -1
-                                                - OntologyNode:
+                                                - node:
                                                     name: solitary
                                                     children:
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - solitarious hopper
                                                                 - solitary
@@ -1916,17 +1916,17 @@ OntologyNode:
                                                                 - instar
                                                             name: solitary_hopper
                                                             polarity: -1
-                                                        - OntologyNode:
+                                                        - node:
                                                             examples:
                                                                 - solitary locust
                                                                 - solitarious adult locust
                                                                 - mature
                                                             name: solitary_locust
                                                             polarity: -1
-                                                - OntologyNode:
+                                                - node:
                                                     name: gregarious
                                                     children:
-                                                        - OntologyNode:
+                                                        - node:
                                                             patterns:
                                                                 - (hopper\s+band)|(bands?\s+of\s+hoppers)
                                                             examples:
@@ -1936,7 +1936,7 @@ OntologyNode:
                                                                 - immature
                                                             name: hopper_band
                                                             polarity: -1
-                                                        - OntologyNode:
+                                                        - node:
                                                             patterns:
                                                                 - (locust\s+swarm)|(swarms?\s+of\s+locust)
                                                             examples:
@@ -1948,7 +1948,7 @@ OntologyNode:
                                                                 - locust outbreak
                                                             name: locust_swarm
                                                             polarity: -1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - planting
                                         - plant
@@ -1956,13 +1956,13 @@ OntologyNode:
                                         - horticulture
                                     name: planting
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - store crops
                                         - granary
                                     name: crop_storage
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - fertilization
                                         - biofertilizers
@@ -1973,7 +1973,7 @@ OntologyNode:
                                         - manure
                                     name: fertilization
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - localized irrigation
                                         - capillary irrigation
@@ -1994,12 +1994,12 @@ OntologyNode:
                                         - irrigation
                                     name: irrigation
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - pesticide
                                     name: pesticide
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - crop yield
                                         - harvest
@@ -2059,7 +2059,7 @@ OntologyNode:
                                         - cultivate
                                     name: crop_production
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - livestock
                                         - cattle
@@ -2074,10 +2074,10 @@ OntologyNode:
                                         - meat production
                                     name: livestock_production
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     name: plant_disease
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - pest infestation
                                                 - armyworm
@@ -2096,40 +2096,40 @@ OntologyNode:
                                                 - pest
                                             name: pest_infestation
                                             polarity: -1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - livestock disease
                                         - livestock diseases
                                     name: livestock_disease
                                     polarity: -1
-                        - OntologyNode:
+                        - node:
                             name: wild_food_sources
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - gather gathering wild foods
                                         - forage
                                         - foraging
                                     name: foraging_wild_foods
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - hunting
                                         - trapping
                                     name: hunting
                                     polarity: 1
-                        - OntologyNode:
+                        - node:
                             name: health_and_life
                             children:
-                                - OntologyNode:
+                                - node:
                                     name: living_condition
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - food safety
                                             name: food_safety
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - water safety
                                                 - unsafe water
@@ -2137,22 +2137,22 @@ OntologyNode:
                                                 - unpotable
                                             name: water_safety
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - unsanitary condition
                                                 - unclean workspaces
                                                 - unclean unsafe living conditions
                                             name: sanitation_and_hygiene
                                             polarity: 1
-                                - OntologyNode:
+                                - node:
                                     name: nutrition
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - food intake
                                             name: food_intake
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - food diversity
                                                 - food variety
@@ -2161,14 +2161,14 @@ OntologyNode:
                                                 - nutritional security
                                             name: food_diversity
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - food preparation
                                                 - cooking
                                                 - meal preparation
                                             name: food_preparation
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - food preference
                                                 - seed preference
@@ -2176,7 +2176,7 @@ OntologyNode:
                                                 - food taste choice
                                             name: food_preference
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - food gap
                                                 - malnutrition
@@ -2187,24 +2187,24 @@ OntologyNode:
                                                 - food riots
                                             name: malnutrition
                                             polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - breast feeding
                                                 - breastfeeding
                                                 - breastfed
                                             name: breast_feeding
                                             polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - biometrics
                                         - fingerprint
                                         - human features
                                     name: biometrics
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     name: disease
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - transmission
                                                 - community spread
@@ -2212,7 +2212,7 @@ OntologyNode:
                                                 - virus
                                             name: transmission
                                             polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             patterns:
                                                 - (COVID|covid)
                                             examples:
@@ -2221,7 +2221,7 @@ OntologyNode:
                                                 - coronavirus
                                             name: covid_virus
                                             polarity: -1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - HIV
                                                 - malaria
@@ -2249,17 +2249,17 @@ OntologyNode:
                                                 - infectious
                                             name: human_disease
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - alcohol drug and substance abuse
                                                 - alcohol abuse
                                                 - drug rehabilitation
                                             name: alcohol_drug_and_substance_abuse
                                             polarity: -1
-                                - OntologyNode:
+                                - node:
                                     name: treatment
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - disease treatment
                                                 - medication
@@ -2270,7 +2270,7 @@ OntologyNode:
                                                 - surgery
                                             name: health_treatment
                                             polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - death
                                         - mortality
@@ -2286,13 +2286,13 @@ OntologyNode:
                                         - murder
                                     name: death
                                     polarity: -1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - injury
                                         - wounds
                                     name: injury
                                     polarity: -1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - birth
                                         - childbirth
@@ -2300,25 +2300,25 @@ OntologyNode:
                                         - born
                                     name: birth
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - basic needs
                                         - population needs
                                         - humanitarian needs
                                     name: basic_needs
                                     polarity: 1
-                        - OntologyNode:
+                        - node:
                             name: access
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - market access
                                     name: market_access
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     name: infrastructure_access
                                     children:
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - energy
                                                 - electric plant
@@ -2329,7 +2329,7 @@ OntologyNode:
                                                 - electrical services
                                             name: electrical
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - waste
                                                 - sewage treatment
@@ -2337,7 +2337,7 @@ OntologyNode:
                                                 - garbage removal
                                             name: waste
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - highway access
                                                 - road network access
@@ -2347,22 +2347,22 @@ OntologyNode:
                                                 - road conditions
                                             name: road_access
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - bridge
                                             name: bridge
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             examples:
                                                 - construction materials
                                                 - access to construction materials
                                                 - availability of building materials
                                             name: construction_materials
                                             polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             name: transportation
                                             children:
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - transit system
                                                         - public transportation
@@ -2372,23 +2372,23 @@ OntologyNode:
                                                         - air services
                                                     name: travel
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - shipping
                                                         - freight
                                                         - cargo
                                                     name: shipping
                                                     polarity: 1
-                                        - OntologyNode:
+                                        - node:
                                             name: medical
                                             children:
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - ambulances
                                                         - EMS
                                                     name: ambulances
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - hospital
                                                         - clinic
@@ -2398,7 +2398,7 @@ OntologyNode:
                                                         - access to hospitals
                                                     name: medical_facility
                                                     polarity: 1
-                                                - OntologyNode:
+                                                - node:
                                                     examples:
                                                         - medical workers
                                                         - health workers
@@ -2407,7 +2407,7 @@ OntologyNode:
                                                         - first responders
                                                     name: medical_workers
                                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - water insecurity
                                         - water shortage
@@ -2444,7 +2444,7 @@ OntologyNode:
                                         - water supply
                                     name: water_access
                                     polarity: 1
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - trend
                                 - trends
@@ -2458,10 +2458,10 @@ OntologyNode:
                                 - improved
                             name: trend
                             polarity: 1
-                        - OntologyNode:
+                        - node:
                             name: food_security
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - food availability
                                         - food security
@@ -2470,40 +2470,40 @@ OntologyNode:
                                     name: food_availability
                                     opposite: wm/concept/causal_factor/food_insecurity/food_unavailability
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - food production
                                         - producing food
                                     name: food_production
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - food utilization
                                         - consumption of enough food
                                     name: food_utilization
                                     opposite: wm/concept/causal_factor/food_insecurity/food_nonutilization
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - household food storage
                                     name: household_food_storage
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - food access
                                     name: food_access
                                     opposite: wm/concept/causal_factor/food_insecurity/food_nonaccess
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - food stability
                                     name: food_stability
                                     opposite: wm/concept/causal_factor/food_insecurity/food_instability
                                     polarity: 1
-                        - OntologyNode:
+                        - node:
                             name: food_insecurity
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - food insecurity
                                         - food scarcity
@@ -2516,7 +2516,7 @@ OntologyNode:
                                     name: food_unavailability
                                     opposite: wm/concept/causal_factor/food_security/food_availability
                                     polarity: -1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - food wasting
                                         - food wastage
@@ -2524,28 +2524,28 @@ OntologyNode:
                                     name: food_nonutilization
                                     opposite: wm/concept/causal_factor/food_security/food_utilization
                                     polarity: -1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - food nonaccess
                                         - unable to access food supplies
                                     name: food_nonaccess
                                     opposite: wm/concept/causal_factor/food_security/food_access
                                     polarity: -1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - food instability
                                     name: food_instability
                                     opposite: wm/concept/causal_factor/food_security/food_stability
                                     polarity: -1
-                - OntologyNode:
+                - node:
                     name: entity
                     children:
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - geographic location
                             name: geo-location
                             polarity: 1
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - commission
                                 - workshop
@@ -2558,16 +2558,16 @@ OntologyNode:
                                 - convention
                             name: organization
                             polarity: 1
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - government entity
                                 - program entity
                             name: government_entity
                             polarity: 1
-                        - OntologyNode:
+                        - node:
                             name: person_and_group
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - people group
                                         - people
@@ -2576,7 +2576,7 @@ OntologyNode:
                                         - rural
                                     name: population
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - community
                                         - villages
@@ -2586,18 +2586,18 @@ OntologyNode:
                                         - communities
                                     name: community
                                     polarity: 1
-                        - OntologyNode:
+                        - node:
                             examples:
                                 - artifact
                             name: artifact
                             polarity: 1
-                - OntologyNode:
+                - node:
                     name: time
                     children:
-                        - OntologyNode:
+                        - node:
                             name: temporal
                             children:
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - harvest
                                         - lean season
@@ -2605,7 +2605,7 @@ OntologyNode:
                                         - sowing season
                                     name: crop_season
                                     polarity: 1
-                                - OntologyNode:
+                                - node:
                                     examples:
                                         - summer
                                         - winter

--- a/wm_flat_metadata.yml
+++ b/wm_flat_metadata.yml
@@ -25,6 +25,7 @@ node:
                                                     name: livestock_production_inputs
                                                     children:
                                                         - node:
+                                                            name: livestock_feed
                                                             examples:
                                                                 - livestock feed
                                                                 - hay
@@ -32,25 +33,25 @@ node:
                                                                 - silage
                                                                 - corn meal
                                                                 - soybean hulls
-                                                            name: livestock_feed
                                                             polarity: 1
                                                         - node:
+                                                            name: veterinary_services
                                                             examples:
                                                                 - veterinary services medicine
                                                                 - animal birthing
                                                                 - antibiotics
                                                                 - livestock vaccination
-                                                            name: veterinary_services
                                                             polarity: 1
                                                         - node:
+                                                            name: livestock_watering
                                                             examples:
                                                                 - livestock watering
-                                                            name: livestock_watering
                                                             polarity: 1
                                                 - node:
                                                     name: crop_production_equipment
                                                     children:
                                                         - node:
+                                                            name: farm_equipment
                                                             examples:
                                                                 - farm equipment
                                                                 - machinery
@@ -59,54 +60,54 @@ node:
                                                                 - row planter
                                                                 - plow
                                                                 - winnower
-                                                            name: farm_equipment
                                                             polarity: 1
                                                         - node:
+                                                            name: harvesting_equipment
                                                             examples:
                                                                 - harvesting equipment
                                                                 - baskets
                                                                 - pickers
                                                                 - ladders
                                                                 - clippers
-                                                            name: harvesting_equipment
                                                             polarity: 1
                                                         - node:
+                                                            name: seed
                                                             examples:
                                                                 - seed
                                                                 - planting
-                                                            name: seed
                                                             polarity: 1
                                                         - node:
                                                             name: irrigation_equipment
                                                             children:
                                                                 - node:
+                                                                    name: water_source
                                                                     examples:
                                                                         - water source
                                                                         - wells
                                                                         - bore-holes
                                                                         - irrigation ditch
                                                                         - canal
-                                                                    name: water_source
                                                                     polarity: 1
                                                                 - node:
+                                                                    name: pumps
                                                                     examples:
                                                                         - water pumps
                                                                         - treadle
                                                                         - electric pump
                                                                         - small scale irrigation pump
-                                                                    name: pumps
                                                                     polarity: 1
                                                                 - node:
+                                                                    name: field_irrigation
                                                                     examples:
                                                                         - field irrigation
                                                                         - drip
                                                                         - sprinklers
-                                                                    name: field_irrigation
                                                                     polarity: 1
                                                         - node:
                                                             name: soil_inputs
                                                             children:
                                                                 - node:
+                                                                    name: fertilizer
                                                                     examples:
                                                                         - fertilizer
                                                                         - DAP
@@ -116,21 +117,21 @@ node:
                                                                         - nitrogen
                                                                         - potassium
                                                                         - phosphorous
-                                                                    name: fertilizer
                                                                     polarity: 1
                                                                 - node:
+                                                                    name: fertilizer_subsidy
                                                                     examples:
                                                                         - fertilizer subsidy
                                                                         - fertilizer voucher
                                                                         - cash
                                                                         - price control
                                                                         - fertilizer coupon
-                                                                    name: fertilizer_subsidy
                                                                     polarity: 1
                                                         - node:
                                                             name: weed_pest_control
                                                             children:
                                                                 - node:
+                                                                    name: biological
                                                                     examples:
                                                                         - biological pest weed control
                                                                         - crop rotation
@@ -138,9 +139,9 @@ node:
                                                                         - integrated pest management
                                                                         - IPM
                                                                         - companion planting
-                                                                    name: biological
                                                                     polarity: 1
                                                                 - node:
+                                                                    name: chemical
                                                                     patterns:
                                                                         - \b(DDT|dicamba|round-up)\b
                                                                     examples:
@@ -149,20 +150,20 @@ node:
                                                                         - round-up
                                                                         - dicamba
                                                                         - DDT
-                                                                    name: chemical
                                                                     polarity: 1
                                                                 - node:
+                                                                    name: organic
                                                                     examples:
                                                                         - organic pest weed control
                                                                         - vinegar
                                                                         - pine oil
                                                                         - neem oil
-                                                                    name: organic
                                                                     polarity: 1
                                                 - node:
                                                     name: post_harvest_inputs
                                                     children:
                                                         - node:
+                                                            name: processing_equipment
                                                             examples:
                                                                 - harvest processing equipment
                                                                 - thresher
@@ -173,28 +174,28 @@ node:
                                                                 - harvest laser sorter
                                                                 - tarp
                                                                 - harvest drier racks
-                                                            name: processing_equipment
                                                             polarity: 1
                                                         - node:
+                                                            name: packaging
                                                             examples:
                                                                 - harvest packaging
                                                                 - packing lines
                                                                 - branding
                                                                 - packaging material
-                                                            name: packaging
                                                             polarity: 1
                                                         - node:
+                                                            name: warehousing
                                                             examples:
                                                                 - warehousing
                                                                 - warehouse receipt system
                                                                 - WRS
                                                                 - storage
-                                                            name: warehousing
                                                             polarity: 1
                                         - node:
                                             name: information_services
                                             children:
                                                 - node:
+                                                    name: surveillance_system
                                                     patterns:
                                                         - \b(IPC|FEWS|VAM)\b
                                                         - \bearly\s+warning\s+system\b
@@ -210,22 +211,22 @@ node:
                                                         - FEWS NET
                                                         - vulnerability analysis mapping
                                                         - VAM
-                                                    name: surveillance_system
                                                     polarity: 1
                                                 - node:
+                                                    name: weather_monitoring
                                                     examples:
                                                         - weather monitoring
-                                                    name: weather_monitoring
                                                     polarity: 1
                                                 - node:
+                                                    name: price_monitoring
                                                     examples:
                                                         - price monitoring
-                                                    name: price_monitoring
                                                     polarity: 1
                                                 - node:
                                                     name: human_rights_monitoring
                                                     children:
                                                         - node:
+                                                            name: victims
                                                             examples:
                                                                 - victims
                                                                 - children victims
@@ -233,30 +234,30 @@ node:
                                                                 - refugees
                                                                 - IDP
                                                                 - ethnic minorities
-                                                            name: victims
                                                             polarity: 1
                                                         - node:
+                                                            name: perpetrators
                                                             examples:
                                                                 - perpetrators
                                                                 - militias
                                                                 - gangs
                                                                 - terrorist groups
                                                                 - non state actors
-                                                            name: perpetrators
                                                             polarity: 1
                                                         - node:
+                                                            name: violations
                                                             examples:
                                                                 - violations
                                                                 - human rights violations crimes
                                                                 - war crimes
                                                                 - gender based violence
                                                                 - GBV
-                                                            name: violations
                                                             polarity: 1
                                                 - node:
                                                     name: statistics
                                                     children:
                                                         - node:
+                                                            name: national_survey
                                                             patterns:
                                                                 - \b(census|AgSS|CFSVA)\b
                                                             examples:
@@ -268,12 +269,12 @@ node:
                                                                 - comprehensive food security and vulnerability assessment
                                                                 - AgSS
                                                                 - agricultural sample survey
-                                                            name: national_survey
                                                             polarity: 1
                                         - node:
                                             name: livelihood_support
                                             children:
                                                 - node:
+                                                    name: food_aid
                                                     examples:
                                                         - food aid
                                                         - food for work
@@ -282,9 +283,9 @@ node:
                                                         - food vouchers
                                                         - free food distribution
                                                         - school feeding
-                                                    name: food_aid
                                                     polarity: 1
                                                 - node:
+                                                    name: nutrition_support
                                                     examples:
                                                         - nutrition support
                                                         - food fortification
@@ -292,15 +293,15 @@ node:
                                                         - infant and young child feeding
                                                         - micro nutrient supplementation
                                                         - supplementary feeding
-                                                    name: nutrition_support
                                                     polarity: 1
                                                 - node:
+                                                    name: water
                                                     examples:
                                                         - water
                                                         - water trucking
-                                                    name: water
                                                     polarity: 1
                                                 - node:
+                                                    name: financial_assistance
                                                     examples:
                                                         - financial assistance
                                                         - cash
@@ -311,9 +312,9 @@ node:
                                                         - once off cash transfer to facilitate return
                                                         - grants
                                                         - remittances
-                                                    name: financial_assistance
                                                     polarity: 1
                                                 - node:
+                                                    name: livelihood_assets
                                                     examples:
                                                         - livelihood assets
                                                         - fishing nets
@@ -323,22 +324,22 @@ node:
                                                         - improved chicken breed
                                                         - bicycle
                                                         - cart
-                                                    name: livelihood_assets
                                                     polarity: 1
                                                 - node:
                                                     name: humanitarian_nonfood_items
                                                     children:
                                                         - node:
+                                                            name: shelter
                                                             examples:
                                                                 - shelter
                                                                 - tents
                                                                 - shelter kits
-                                                            name: shelter
                                                             polarity: 1
                                         - node:
                                             name: medical_inputs
                                             children:
                                                 - node:
+                                                    name: vaccine
                                                     patterns:
                                                         - \b(immuniz(ations?|e))\b
                                                     examples:
@@ -350,9 +351,9 @@ node:
                                                         - polio
                                                         - measles
                                                         - yellow fever
-                                                    name: vaccine
                                                     polarity: 1
                                                 - node:
+                                                    name: medical_treatment
                                                     examples:
                                                         - medical treatment
                                                         - anti retroviral treatment
@@ -365,9 +366,9 @@ node:
                                                         - therapeutic feeding
                                                         - trauma and surgical care
                                                         - trauma and post operative rehabilitation
-                                                    name: medical_treatment
                                                     polarity: 1
                                                 - node:
+                                                    name: prevention
                                                     examples:
                                                         - prevention
                                                         - insecticide treated bednets
@@ -375,18 +376,18 @@ node:
                                                         - preventative medicine
                                                         - well-child visit
                                                         - well-visit
-                                                    name: prevention
                                                     polarity: 1
                                                 - node:
+                                                    name: psychological
                                                     examples:
                                                         - psychological
                                                         - therapy
                                                         - clinical management of sexual violence
                                                         - psychological support
                                                         - therapist counselor
-                                                    name: psychological
                                                     polarity: 1
                                         - node:
+                                            name: sanitation_and_hygiene_inputs
                                             examples:
                                                 - sanitation and hygiene input
                                                 - desludging
@@ -396,7 +397,6 @@ node:
                                                 - solid waste management
                                                 - point of use water treatment
                                                 - piped water supply treatment
-                                            name: sanitation_and_hygiene_inputs
                                             polarity: 1
                                 - node:
                                     name: build
@@ -408,6 +408,7 @@ node:
                                                     name: livestock_production_infrastructure
                                                     children:
                                                         - node:
+                                                            name: livestock_shelter # enclosure, barn, pasture, etc
                                                             examples:
                                                                 - enclosure
                                                                 - barn
@@ -416,30 +417,30 @@ node:
                                                                 - paddock
                                                                 - chicken coop
                                                                 - coop
-                                                            name: livestock_shelter # enclosure, barn, pasture, etc
                                                             polarity: 1
                                                 - node:
                                                     name: crop_production_infrastructure
                                                     children:
                                                         - node:
+                                                            name: irrigation_infrastructure # canal, reservoir, water_tower
                                                             examples:
                                                                 - canal
                                                                 - reservoir
                                                                 - water tower
                                                                 - standpipe
                                                                 - irrigation infrastructure
-                                                            name: irrigation_infrastructure # canal, reservoir, water_tower
                                                             polarity: 1
                                                         - node:
+                                                            name: extension_offices # farmer_training_centers, demonstration plots, etc
                                                             patterns:
                                                                 - \bextension\s+offices?
                                                             examples:
                                                                 - farmer training center
                                                                 - demonstration plot
                                                                 - extension office
-                                                            name: extension_offices # farmer_training_centers, demonstration plots, etc
                                                             polarity: 1
                                                         - node:
+                                                            name: greenhouse # nursery, high_tunnel, etc.
                                                             examples:
                                                                 - nursery
                                                                 - plant nursery
@@ -447,9 +448,9 @@ node:
                                                                 - high tunnel
                                                                 - glasshouse
                                                                 - hothouse
-                                                            name: greenhouse # nursery, high_tunnel, etc.
                                                             polarity: 1
                                                         - node:
+                                                            name: post_harvest_infrastructure # on-farm_processing_facility, silos, cooperative_processing, storage, etc.
                                                             patterns:
                                                                 - \b(tower|bunker|stave|grain)\b\s(silo)
                                                             examples:
@@ -462,9 +463,9 @@ node:
                                                                 - grain elevator
                                                                 - cooperative processing
                                                                 - post-harvest
-                                                            name: post_harvest_infrastructure # on-farm_processing_facility, silos, cooperative_processing, storage, etc.
                                                             polarity: 1
                                         - node:
+                                            name: trade_infrastructure # factory, industrial_park, storage_facilities, warehouse, processing_facilities, etc.
                                             examples:
                                                 - factory
                                                 - industrial park
@@ -472,9 +473,9 @@ node:
                                                 - warehouse
                                                 - processing facility
                                                 - trade infrastructure
-                                            name: trade_infrastructure # factory, industrial_park, storage_facilities, warehouse, processing_facilities, etc.
                                             polarity: 1
                                         - node:
+                                            name: educational_infrastructure # community_centers, child_friendly_learning_spaces, school_rehabilitation, gender_specific_bathrooms, etc.
                                             examples:
                                                 - community center
                                                 - classroom
@@ -483,9 +484,9 @@ node:
                                                 - gender-specific bathrooms
                                                 - educational infrastructure
                                                 - school infrastructure
-                                            name: educational_infrastructure # community_centers, child_friendly_learning_spaces, school_rehabilitation, gender_specific_bathrooms, etc.
                                             polarity: 1
                                         - node:
+                                            name: shelter_housing # permanent_house, temporary_housing, refugee_camp, housing_provision, leasing_or_rental_services, temporary_communal_settlement, etc.
                                             examples:
                                                 - permanent house
                                                 - temporary housing
@@ -496,9 +497,9 @@ node:
                                                 - temporary shelter
                                                 - portable shelter
                                                 - shelter
-                                            name: shelter_housing # permanent_house, temporary_housing, refugee_camp, housing_provision, leasing_or_rental_services, temporary_communal_settlement, etc.
                                             polarity: 1
                                         - node:
+                                            name: WASH_infrastructure # sanitation facilities, latrines, washing_and_bathing_facilities, temporary_water_points, boreholes, permanent_water_points, borehole_repair, etc.
                                             patterns:
                                                 - \b(WASH)\binfrastructure
                                             examples:
@@ -510,9 +511,9 @@ node:
                                                 - permanent water point
                                                 - borehole repair
                                                 - WASH infrastructure
-                                            name: WASH_infrastructure # sanitation facilities, latrines, washing_and_bathing_facilities, temporary_water_points, boreholes, permanent_water_points, borehole_repair, etc.
                                             polarity: 1
                                         - node:
+                                            name: medical_infrastructure # hospitals, mobile clinics, field_hospitals, emergency treatment centers, medical supply chain facilities, etc.
                                             examples:
                                                 - hospital
                                                 - mobile clinic
@@ -522,9 +523,9 @@ node:
                                                 - emergency treatment centre
                                                 - medical supply chain facility
                                                 - medical infrastructure
-                                            name: medical_infrastructure # hospitals, mobile clinics, field_hospitals, emergency treatment centers, medical supply chain facilities, etc.
                                             polarity: 1
                                         - node:
+                                            name: transportation_infrastructure # bridge, repair, all_weather_roads, railway_lines, temporary_roads, road_rehabilitation
                                             patterns:
                                                 - \b(road|bridge|rail)\s(repair)
                                             examples:
@@ -535,9 +536,9 @@ node:
                                                 - road rehabilitation
                                                 - road repair
                                                 - transportation infrastructure
-                                            name: transportation_infrastructure # bridge, repair, all_weather_roads, railway_lines, temporary_roads, road_rehabilitation
                                             polarity: 1
                                         - node:
+                                            name: communication_infrastructure # cell-phone_towers, landlines, etc
                                             examples:
                                                 - internet access service
                                                 - cell-phone tower
@@ -547,9 +548,9 @@ node:
                                                 - telephone pole
                                                 - telepole
                                                 - communication infrastructure
-                                            name: communication_infrastructure # cell-phone_towers, landlines, etc
                                             polarity: 1
                                         - node:
+                                            name: energy_infrastructure # dams, electricity_grids, micro-grids, solar_panels, wind_turbines, wind_farms, solar_farms, etc.
                                             examples:
                                                 - dam
                                                 - electricity grid
@@ -561,7 +562,6 @@ node:
                                                 - wind farm
                                                 - solar farm
                                                 - energy infrastructure
-                                            name: energy_infrastructure # dams, electricity_grids, micro-grids, solar_panels, wind_turbines, wind_farms, solar_farms, etc.
                                             polarity: 1
                                 - node:
                                     name: train
@@ -573,14 +573,15 @@ node:
                                                     name: production_practices
                                                     children:
                                                         - node:
+                                                            name: planting_training # crop_spacing, planting_times, seed_depth, watering, crop_rotation, cover_cropping, composting, low_till, no_till, perennial_planting, Conservation_agriculture
                                                             examples:
                                                                 - cover cropping
                                                                 - composting
                                                                 - planting practices
                                                                 - training
-                                                            name: planting_training # crop_spacing, planting_times, seed_depth, watering, crop_rotation, cover_cropping, composting, low_till, no_till, perennial_planting, Conservation_agriculture
                                                             polarity: 1
                                                         - node:
+                                                            name: pest_weed_control # IPM_practices (integrated pest management), etc
                                                             patterns:
                                                                 - (\bIPM\b)(\s(practices))?
                                                             examples:
@@ -588,9 +589,9 @@ node:
                                                                 - training integrated pest management
                                                                 - training pest control
                                                                 - weed control
-                                                            name: pest_weed_control # IPM_practices (integrated pest management), etc
                                                             polarity: 1
                                                         - node:
+                                                            name: post_harvest_practices # storage, processing, packaging, safety_and_hygiene, certifications, ISO, FDA, work_place_safety, etc.
                                                             examples:
                                                                 - training storage
                                                                 - training processing
@@ -601,9 +602,9 @@ node:
                                                                 - FDA
                                                                 - workplace safety
                                                                 - post-harvest practices
-                                                            name: post_harvest_practices # storage, processing, packaging, safety_and_hygiene, certifications, ISO, FDA, work_place_safety, etc.
                                                             polarity: 1
                                                 - node:
+                                                    name: agriculture_information # digital_extension, famers_almanac, mobile_extension, SMS reminders,  Weather_information,  NMA_reports (national met agency), broadcast_weather_reports,
                                                     patterns:
                                                         - (\bNM[AS]\b)\s(reports?)
                                                     examples:
@@ -611,12 +612,12 @@ node:
                                                         - weather information
                                                         - national weather service meteorological met
                                                         - agriculture information
-                                                    name: agriculture_information # digital_extension, famers_almanac, mobile_extension, SMS reminders,  Weather_information,  NMA_reports (national met agency), broadcast_weather_reports,
                                                     polarity: 1
                                         - node:
                                             name: medical_training
                                             children:
                                                 - node:
+                                                    name: assessment_and_triage_of_health_facilities
                                                     examples:
                                                         - medical training
                                                         - assessment of health facilities
@@ -624,38 +625,38 @@ node:
                                                         - evaluation community health workers
                                                         - CHWs
                                                         - medical capacity assessment
-                                                    name: assessment_and_triage_of_health_facilities
                                                     polarity: 1
                                                 - node:
+                                                    name: capacity_building_of_medical_staff
                                                     examples:
                                                         - capacity building of medical staff
                                                         - medical capacity building
-                                                    name: capacity_building_of_medical_staff
                                                     polarity: 1
                                         - node:
+                                            name: human_rights_training
                                             examples:
                                                 - human rights training
-                                            name: human_rights_training
                                             polarity: 1
                                         - node:
+                                            name: financial_management # provision_of_credit_and_training_for_income_generation
                                             examples:
                                                 - provision of credit
                                                 - training for income generation
                                                 - training credit provision
                                                 - income generation training
                                                 - financial management
-                                            name: financial_management # provision_of_credit_and_training_for_income_generation
                                             polarity: 1
                                         - node:
+                                            name: education_systems #  provision_of_non_formal_education, community_sourced_temporary_teachers
                                             examples:
                                                 - provision of non-formal education
                                                 - training community sourced temporary teachers
                                                 - education systems
                                                 - capacity building of educational staff
                                                 - training education capacity building
-                                            name: education_systems #  provision_of_non_formal_education, community_sourced_temporary_teachers
                                             polarity: 1
                                         - node:
+                                            name: public_health_campaigns # behaviour change, campaigns, public information, hygiene_promotion, information_campaign, health_promoters,
                                             examples:
                                                 - behavior change campaign
                                                 - behaviour change campaign
@@ -665,34 +666,34 @@ node:
                                                 - health promotors
                                                 - health promotion
                                                 - public health campaigns
-                                            name: public_health_campaigns # behaviour change, campaigns, public information, hygiene_promotion, information_campaign, health_promoters,
                                             polarity: 1
                                         - node:
+                                            name: public_safety_campaigns # explosive_hazards
                                             examples:
                                                 - explosive hazards campaign
                                                 - public safety campaigns
-                                            name: public_safety_campaigns # explosive_hazards
                                             polarity: 1
                                         - node:
                                             name: emergency_preparedness_training
                                             children:
                                                 - node:
+                                                    name: surveillance_system_strengthening
                                                     examples:
                                                         - surveillance system strengthening
-                                                    name: surveillance_system_strengthening
                                                     polarity: 1
                                                 - node:
+                                                    name: humanitarian_certifications # SPHERE, core_standards, humanitarian_charter, etc.
                                                     examples:
                                                         - SPHERE
                                                         - core standards
                                                         - humanitarian charter
                                                         - humanitarian certifications
-                                                    name: humanitarian_certifications # SPHERE, core_standards, humanitarian_charter, etc.
                                                     polarity: 1
                                 - node:
                                     name: secure
                                     children:
                                         - node:
+                                            name: livelihood_protections #  agricultural assets, cattle_raids, supply chains,
                                             examples:
                                                 - agricultural assets
                                                 - cattle raid
@@ -705,29 +706,29 @@ node:
                                                 - neutralize threat to livelihood
                                                 - preserve livelihood
                                                 - secure livelihood
-                                            name: livelihood_protections #  agricultural assets, cattle_raids, supply chains,
                                             polarity: 1
                                         - node:
                                             name: community_security
                                             children:
                                                 - node:
+                                                    name: mine_clearance
                                                     examples:
                                                         - mine clearance
                                                         - demining
                                                         - remove land mines
                                                         - clear land mines
                                                         - neutralize land mines
-                                                    name: mine_clearance
                                                     polarity: 1
                                                 - node:
+                                                    name: temporary_policing_services
                                                     examples:
                                                         - temporary policing services
                                                         - temporary police
                                                         - temporary security services
                                                         - security escort
-                                                    name: temporary_policing_services
                                                     polarity: 1
                                         - node:
+                                            name: conflict_resolution # conflict_mediation, political_dialogue, disarmament, demobilization, reintegration, family_reunification, rehabilitation_of_child_soldier
                                             patterns:
                                                 - peace\s+(building|talks)
                                                 - conflict\s+resolution
@@ -740,9 +741,9 @@ node:
                                                 - family reunification
                                                 - rehabilitation of child soldiers
                                                 - conflict resolution
-                                            name: conflict_resolution # conflict_mediation, political_dialogue, disarmament, demobilization, reintegration, family_reunification, rehabilitation_of_child_soldier
                                             polarity: 1
                                         - node:
+                                            name: secure_natural_resources # Water_rights, Land_rights, land_deeds, Biotechnology, etc.
                                             examples:
                                                 - water rights
                                                 - land rights
@@ -755,28 +756,28 @@ node:
                                                 - neutralize threat to natural resources
                                                 - preserve natural resources
                                                 - secure natural resources
-                                            name: secure_natural_resources # Water_rights, Land_rights, land_deeds, Biotechnology, etc.
                                             polarity: 1
                                         - node:
+                                            name: cultural_resources # landmark_designation, world_heritage_status, etc.
                                             patterns:
                                                 - \bUNESCO\b\sworld\sheritage\ssite
                                             examples:
                                                 - landmark designation conservation
                                                 - world heritage status site
                                                 - cultural resources protections
-                                            name: cultural_resources # landmark_designation, world_heritage_status, etc.
                                             polarity: 1
                                 - node:
                                     name: legislate
                                     children:
                                         - node:
+                                            name: subsidize
                                             examples:
                                                 - subsidize
                                                 - subsidies
                                                 - subsidy
-                                            name: subsidize
                                             polarity: 1
                                         - node:
+                                            name: tax
                                             examples:
                                                 - tax
                                                 - taxation
@@ -784,9 +785,9 @@ node:
                                                 - tax legislation
                                                 - duty
                                                 - tariff
-                                            name: tax
                                             polarity: 1
                                         - node:
+                                            name: control_prices
                                             examples:
                                                 - control prices
                                                 - price control
@@ -794,7 +795,6 @@ node:
                                                 - legislate prices
                                                 - price ceiling
                                                 - price floor
-                                            name: control_prices
                                             polarity: 1
                         - node:
                             name: environmental
@@ -803,6 +803,7 @@ node:
                                     name: meteorologic
                                     children:
                                         - node:
+                                            name: weather
                                             examples:
                                                 - weather
                                                 - weather systems
@@ -814,34 +815,34 @@ node:
                                                 - climate variability
                                                 - snow
                                                 - humid
-                                            name: weather
                                             polarity: 1
                                         - node:
+                                            name: climate
                                             examples:
                                                 - climate
                                                 - tropical
                                                 - equatorial
-                                            name: climate
                                             polarity: 1
                                         - node:
                                             name: precipitation
                                             children:
                                                 - node:
+                                                    name: rainfall
                                                     examples:
                                                         - rainfall
                                                         - precipitation
                                                         - rains
                                                         - rain
-                                                    name: rainfall
                                                     polarity: 1
                                                 - node:
+                                                    name: storm
                                                     examples:
                                                         - storm
                                                         - seasonal monsoon
                                                         - extreme weather
-                                                    name: storm
                                                     polarity: 1
                                         - node:
+                                            name: temperature # temperature of ...
                                             examples:
                                                 - temperature
                                                 - cooler
@@ -853,20 +854,20 @@ node:
                                                 - record highs
                                                 - warmer
                                                 - warming
-                                            name: temperature # temperature of ...
                                             polarity: 1
                                 - node:
+                                    name: environment
                                     examples:
                                         - environment
-                                    name: environment
                                     polarity: 1
                                 - node:
+                                    name: climate_change_mitigation
                                     examples:
                                         - climate change mitigation
                                         - climate change adaptation
-                                    name: climate_change_mitigation
                                     polarity: 1
                                 - node:
+                                    name: resource_management
                                     examples:
                                         - conservation
                                         - sustainable use
@@ -876,9 +877,9 @@ node:
                                         - management forest
                                         - depleted resources
                                         - overexploitation
-                                    name: resource_management
                                     polarity: 1
                                 - node:
+                                    name: forestry
                                     examples:
                                         - afforestation
                                         - agroforestry
@@ -886,12 +887,12 @@ node:
                                         - reforestation
                                         - forestry
                                         - logging
-                                    name: forestry
                                     polarity: 1
                                 - node:
                                     name: natural_resources
                                     children:
                                         - node:
+                                            name: water_bodies
                                             examples:
                                                 - water
                                                 - sea
@@ -905,49 +906,49 @@ node:
                                                 - snow melt
                                                 - water body
                                                 - reservoir
-                                            name: water_bodies
                                             polarity: 1
                                         - node:
+                                            name: land_availability
                                             examples:
                                                 - land availability
                                                 - availability of cropland
-                                            name: land_availability
                                             polarity: 1
                                         - node:
+                                            name: fossil_fuels
                                             examples:
                                                 - fossil fuels
                                                 - coal
                                                 - oil
                                                 - natural gas
-                                            name: fossil_fuels
                                             polarity: 1
                                         - node:
+                                            name: soil
                                             examples:
                                                 - soil
                                                 - soil quality
                                                 - leaching into the soil
-                                            name: soil
                                             polarity: 1
                                         - node:
+                                            name: pasture
                                             examples:
                                                 - pastoral conditions
                                                 - pasture conditions
                                                 - rangeland conditions
                                                 - vegetation conditions
                                                 - grazing conditions
-                                            name: pasture
                                             polarity: 1
                                 - node:
                                     name: pollution
                                     children:
                                         - node:
+                                            name: air_pollution
                                             examples:
                                                 - pollution
                                                 - greenhouse gas emission
                                                 - ghg emission
-                                            name: air_pollution
                                             polarity: -1
                                         - node:
+                                            name: land_pollution
                                             examples:
                                                 - contaminant
                                                 - contamination
@@ -958,14 +959,13 @@ node:
                                                 - pollution
                                                 - leakage
                                                 - acidification
-                                            name: land_pollution
                                             polarity: -1
                                         - node:
+                                            name: climate_change
                                             examples:
                                                 - deforestation
                                                 - desertification
                                                 - climate change
-                                            name: climate_change
                                             polarity: -1
                         - node:
                             name: crisis_and_disaster
@@ -974,32 +974,33 @@ node:
                                     name: health
                                     children:
                                         - node:
+                                            name: pandemic
                                             examples:
                                                 - disease outbreak
                                                 - global pandemic
                                                 - pandemic
                                                 - epidemic
-                                            name: pandemic
                                             polarity: -1
                                         - node:
                                             name: mitigation
                                             children:
                                                 - node:
+                                                    name: sanitation
                                                     examples:
                                                         - sanitation
                                                         - hygiene materials
                                                         - soap
                                                         - wash hands
-                                                    name: sanitation
                                                     polarity: 1
                                                 - node:
+                                                    name: contact_tracing
                                                     patterns:
                                                         - (contact tracing)
                                                     examples:
                                                         - contact tracing
-                                                    name: contact_tracing
                                                     polarity: 1
                                                 - node:
+                                                    name: quarantine
                                                     patterns:
                                                         - (quarantin|shelter[- ]in[- ]place)
                                                     examples:
@@ -1007,23 +1008,23 @@ node:
                                                         - shelter in place
                                                         - isolation
                                                         - restrict movements
-                                                    name: quarantine
                                                     polarity: 1
                                                 - node:
+                                                    name: social_distancing
                                                     patterns:
                                                         - (social distancing)
                                                     examples:
                                                         - social distancing
-                                                    name: social_distancing
                                                     polarity: 1
                                                 - node:
+                                                    name: masks
                                                     examples:
                                                         - masks
                                                         - mask requirements
                                                         - wearing face coverings
-                                                    name: masks
                                                     polarity: 1
                                 - node:
+                                    name: famine
                                     examples:
                                         - famine
                                         - hunger
@@ -1033,84 +1034,84 @@ node:
                                         - severe food insecurity
                                         - global acute malnutrition
                                         - acute malnutrition
-                                    name: famine
                                     polarity: -1
                                 - node:
+                                    name: crisis
                                     examples:
                                         - crisis
                                         - crises
                                         - emergency
                                         - disasters
                                         - catastrophe
-                                    name: crisis
                                     polarity: -1
                                 - node:
                                     name: economic
                                     children:
                                         - node:
+                                            name: economic_crisis
                                             examples:
                                                 - economic crisis
                                                 - financial crisis
                                                 - economic volatility
-                                            name: economic_crisis
                                             polarity: -1
                                 - node:
                                     name: environmental_disasters
                                     children:
                                         - node:
+                                            name: crop_failure
                                             examples:
                                                 - crop failure
                                                 - loss of crops
                                                 - decimated crop yields
-                                            name: crop_failure
                                             polarity: -1
                                         - node:
+                                            name: insect_infestation
                                             examples:
                                                 - insect infestation
-                                            name: insect_infestation
                                             polarity: -1
                                         - node:
                                             name: natural_disaster
                                             children:
                                                 - node:
+                                                    name: flooding
                                                     examples:
                                                         - flood
                                                         - floods
                                                         - flooding
                                                         - flash flood
-                                                    name: flooding
                                                     polarity: -1
                                                 - node:
+                                                    name: avalanche
                                                     examples:
                                                         - avalanche
-                                                    name: avalanche
                                                     polarity: -1
                                                 - node:
+                                                    name: wildfire
                                                     examples:
                                                         - wildfire
-                                                    name: wildfire
                                                     polarity: -1
                                                 - node:
+                                                    name: volcanic_eruption
                                                     examples:
                                                         - volcanic eruption
-                                                    name: volcanic_eruption
                                                     polarity: -1
                                                 - node:
+                                                    name: drought
                                                     examples:
                                                         - drought
                                                         - droughts
                                                         - low rainfall
-                                                    name: drought
                                                     polarity: -1
                                                 - node:
+                                                    name: earthquake
                                                     examples:
                                                         - earthquake
-                                                    name: earthquake
                                                     polarity: -1
                                         - node:
                                             name: weather_issue
                                             children:
                                                 - node:
+                                                    name: cold_temperature
                                                     examples:
                                                         - cold temperature
                                                         - frigid conditions
@@ -1118,24 +1119,23 @@ node:
                                                         - arctic winds
                                                         - winter emergency
                                                         - state of emergency due to cold weather
-                                                    name: cold_temperature
                                                     polarity: -1
                                         - node:
+                                            name: fire # what is on fire?
                                             examples:
                                                 - fire
                                                 - blaze
                                                 - wildfires
                                                 - burned
-                                            name: fire # what is on fire?
                                             polarity: -1
                         - node:
                             name: economic_and_commerce
                             children:
                                 - node:
+                                    name: poverty
                                     examples:
                                         - poverty
                                         - poor
-                                    name: poverty
                                     polarity: -1
                                 - node:
                                     name: economic_activity
@@ -1144,11 +1144,12 @@ node:
                                             name: livelihood
                                             children:
                                                 - node:
+                                                    name: farming
                                                     examples:
                                                         - farming
-                                                    name: farming
                                                     polarity: 1
                                         - node:
+                                            name: currency
                                             examples:
                                                 - currency
                                                 - dollar
@@ -1157,7 +1158,6 @@ node:
                                                 - money
                                                 - hard currency
                                                 - foreign exchange
-                                            name: currency
                                             polarity: 1
                                         - node:
                                             name: cross_border_trade
@@ -1166,6 +1166,7 @@ node:
                                                     name: import
                                                     children:
                                                         - node:
+                                                            name: food_import # thing imported
                                                             examples:
                                                                 - imported foods
                                                                 - crop imports
@@ -1174,12 +1175,12 @@ node:
                                                                 - imports of staples
                                                                 - international crop trade
                                                                 - food trade between countries
-                                                            name: food_import # thing imported
                                                             polarity: 1
                                                 - node:
                                                     name: export
                                                     children:
                                                         - node:
+                                                            name: food_export # thing exported
                                                             examples:
                                                                 - crop exports
                                                                 - food exports
@@ -1188,12 +1189,12 @@ node:
                                                                 - exports of staples
                                                                 - international crop trade
                                                                 - food trade between countries
-                                                            name: food_export # thing exported
                                                             polarity: 1
                                         - node:
                                             name: market
                                             children:
                                                 - node:
+                                                    name: labor_market
                                                     examples:
                                                         - labor market
                                                         - labour market
@@ -1202,9 +1203,9 @@ node:
                                                         - employment
                                                         - recruit
                                                         - find work
-                                                    name: labor_market
                                                     polarity: 1
                                                 - node:
+                                                    name: fuel
                                                     examples:
                                                         - fuel
                                                         - biofuel
@@ -1218,12 +1219,12 @@ node:
                                                         - petrol
                                                         - diesel
                                                         - oil production
-                                                    name: fuel
                                                     polarity: 1
                                                 - node:
                                                     name: price_or_cost
                                                     children:
                                                         - node:
+                                                            name: food_price
                                                             examples:
                                                                 - food price
                                                                 - food prices
@@ -1239,9 +1240,9 @@ node:
                                                                 - rice prices
                                                                 - high food prices
                                                                 - grain cost
-                                                            name: food_price
                                                             polarity: 1
                                                         - node:
+                                                            name: crop_price
                                                             examples:
                                                                 - bamboo prices
                                                                 - banana prices
@@ -1287,120 +1288,120 @@ node:
                                                                 - vegetable prices
                                                                 - wheat prices
                                                                 - white maize prices
-                                                            name: crop_price
                                                             polarity: 1
                                                         - node:
+                                                            name: oil_price
                                                             examples:
                                                                 - oil price
                                                                 - cost of crude oil
-                                                            name: oil_price
                                                             polarity: 1
                                                         - node:
+                                                            name: cost_of_living
                                                             examples:
                                                                 - cost of living
                                                                 - rent
                                                                 - housing cost
-                                                            name: cost_of_living
                                                             polarity: 1
                                                         - node:
+                                                            name: cost_of_transportation
                                                             examples:
                                                                 - cost of transportation
                                                                 - rising transit costs
                                                                 - fuel prices
-                                                            name: cost_of_transportation
                                                             polarity: 1
                                                 - node:
                                                     name: revenue
                                                     children:
                                                         - node:
+                                                            name: household_income
                                                             examples:
                                                                 - household income
                                                                 - take home pay
                                                                 - wages
                                                                 - compensation
-                                                            name: household_income
                                                             polarity: 1
                                                         - node:
+                                                            name: farmer_income
                                                             examples:
                                                                 - farmer income
                                                                 - seasonal income
-                                                            name: farmer_income
                                                             polarity: 1
                                                 - node:
+                                                    name: budget
                                                     examples:
                                                         - budget
                                                         - budgetary constraints
                                                         - fiscal deficits
-                                                    name: budget
                                                     polarity: 1
                                                 - node:
+                                                    name: assets
                                                     examples:
                                                         - assets
                                                         - property
                                                         - land assets
-                                                    name: assets
                                                     polarity: 1
                                                 - node:
                                                     name: supply
                                                     children:
                                                         - node:
+                                                            name: food_supply
                                                             examples:
                                                                 - food supply
                                                                 - market supply of crops
                                                                 - maize supply
                                                                 - domestic food supplies
                                                                 - supplies of food crops
-                                                            name: food_supply
                                                             polarity: 1
                                                 - node:
                                                     name: demand
                                                     children:
                                                         - node:
+                                                            name: food_demand
                                                             examples:
                                                                 - food demand
                                                                 - maize demand
                                                                 - market demand for crops
-                                                            name: food_demand
                                                             polarity: 1
                                                 - node:
                                                     name: transaction
                                                     children:
                                                         - node:
+                                                            name: oil_transaction
                                                             examples:
                                                                 - oil transaction
                                                                 - purchasing crude oil
                                                                 - oil trade
                                                                 - selling barrels
-                                                            name: oil_transaction
                                                             polarity: 1
                                                         - node:
+                                                            name: food_purchase
                                                             examples:
                                                                 - purchasing food
-                                                            name: food_purchase
                                                             polarity: 1
                                                 - node:
+                                                    name: depreciation
                                                     examples:
                                                         - depreciation
                                                         - depreciating
                                                         - devaluation
                                                         - decreased in value
-                                                    name: depreciation
                                                     polarity: -1
                                                 - node:
+                                                    name: inflation
                                                     examples:
                                                         - inflation
                                                         - hyperinflation
                                                         - inflationary pressure
-                                                    name: inflation
                                                     polarity: -1
                                                 - node:
+                                                    name: currency_devaluation
                                                     examples:
                                                         - currency devaluation
                                                         - devaluate
                                                         - currency devalued
-                                                    name: currency_devaluation
                                                     polarity: -1
                                                 - node:
+                                                    name: food_stocks
                                                     examples:
                                                         - food stocks
                                                         - food reserves
@@ -1409,9 +1410,9 @@ node:
                                                         - grain reserves
                                                         - food emergency reserves
                                                         - price stabilization reserves
-                                                    name: food_stocks
                                                     polarity: 1
                                         - node:
+                                            name: competition # between? about?
                                             examples:
                                                 - business competition
                                                 - competitors
@@ -1419,25 +1420,24 @@ node:
                                                 - competition for resources
                                                 - economic competition
                                                 - market pressure
-                                            name: competition # between? about?
                                             polarity: 1
                                         - node:
+                                            name: development # being developed
                                             examples:
                                                 - development
                                                 - economic development
                                                 - rural development
                                                 - agricultural development
-                                            name: development # being developed
                                             polarity: 1
                         - node:
                             name: research_development
                             children:
                                 - node:
+                                    name: technology_and_innovation
                                     examples:
                                         - novel new technology
                                         - research innovation
                                         - breakthrough technology
-                                    name: technology_and_innovation
                                     polarity: 1
                         - node:
                             name: social_and_political
@@ -1446,21 +1446,22 @@ node:
                                     name: communication
                                     children:
                                         - node:
+                                            name: planning
                                             examples:
                                                 - planning
                                                 - develop plans
-                                            name: planning
                                             polarity: 1
                                         - node:
+                                            name: discussion_debate
                                             examples:
                                                 - discussion
                                                 - debate
                                                 - communication
                                                 - discourse
                                                 - dialogue
-                                            name: discussion_debate
                                             polarity: 1
                                         - node:
+                                            name: collaboration
                                             examples:
                                                 - collaboration
                                                 - collaborate
@@ -1468,41 +1469,41 @@ node:
                                                 - partner
                                                 - pact
                                                 - consortium
-                                            name: collaboration
                                             polarity: 1
                                 - node:
+                                    name: basic_services
                                     examples:
                                         - basic services
                                         - primary services
                                         - essential services
-                                    name: basic_services
                                     polarity: 1
                                 - node:
                                     name: population_group
                                     children:
                                         - node:
+                                            name: population_density
                                             examples:
                                                 - population density
                                                 - local population
-                                            name: population_density
                                             polarity: 1
                                         - node:
+                                            name: de-population
                                             examples:
                                                 - depopulation
                                                 - de-population
-                                            name: de-population
                                             polarity: -1
                                         - node:
+                                            name: overcrowding
                                             examples:
                                                 - overcrowding
                                                 - over-crowding
                                                 - population density
-                                            name: overcrowding
                                             polarity: -1
                                 - node:
                                     name: educational
                                     children:
                                         - node:
+                                            name: education
                                             examples:
                                                 - literacy
                                                 - education
@@ -1512,27 +1513,27 @@ node:
                                                 - classroom
                                                 - school leadership
                                                 - access to education
-                                            name: education
                                             polarity: 1
                                         - node:
+                                            name: educational_materials
                                             examples:
                                                 - educational materials
                                                 - reading materials
                                                 - teaching aids
                                                 - classroom supplies
                                                 - school supplies
-                                            name: educational_materials
                                             polarity: 1
                                 - node:
                                     name: government
                                     children:
                                         - node:
+                                            name: census
                                             examples:
                                                 - census
                                                 - survey
-                                            name: census
                                             polarity: 1
                                         - node:
+                                            name: regulation # topic
                                             examples:
                                                 - regulation
                                                 - governance
@@ -1541,9 +1542,9 @@ node:
                                                 - policy
                                                 - legislation
                                                 - policies
-                                            name: regulation # topic
                                             polarity: 1
                                         - node:
+                                            name: tax_duty
                                             examples:
                                                 - tax duty
                                                 - taxes
@@ -1552,21 +1553,21 @@ node:
                                                 - tariff
                                                 - export taxes
                                                 - excise
-                                            name: tax_duty
                                             polarity: 1
                                 - node:
                                     name: political
                                     children:
                                         - node:
+                                            name: political_instability
                                             examples:
                                                 - political instability
                                                 - power struggle
                                                 - regime breakdown
                                                 - political violence
                                                 - unrest
-                                            name: political_instability
                                             polarity: -1
                                         - node:
+                                            name: corruption
                                             examples:
                                                 - corruption
                                                 - fraud
@@ -1574,27 +1575,27 @@ node:
                                                 - bribery
                                                 - extortion
                                                 - nepotism
-                                            name: corruption
                                             polarity: -1
                                         - node:
+                                            name: independence
                                             examples:
                                                 - independence
                                                 - self-rule
                                                 - political independence
-                                            name: independence
                                             polarity: 1
                                         - node:
+                                            name: sanction
                                             examples:
                                                 - sanction
                                                 - economic sanctions
                                                 - diplomatic sanctions
                                                 - sanctioned
-                                            name: sanction
                                             polarity: -1
                                 - node:
                                     name: migration
                                     children:
                                         - node:
+                                            name: human_migration
                                             examples:
                                                 - migration
                                                 - displacement
@@ -1612,18 +1613,18 @@ node:
                                                 - refugee population
                                                 - IDPs
                                                 - human displacement
-                                            name: human_migration
                                             polarity: 1
                                         - node:
+                                            name: hosting_idps
                                             examples:
                                                 - hosting IDPs
                                                 - internal displacement
                                                 - host internally displaced persons
                                                 - host refugees
                                                 - host migrants
-                                            name: hosting_idps
                                             polarity: 1
                                         - node:
+                                            name: emigration
                                             examples:
                                                 - emigration
                                                 - leaving
@@ -1633,9 +1634,9 @@ node:
                                                 - fleeing
                                                 - fled
                                                 - refugees from countries
-                                            name: emigration
                                             polarity: 1
                                         - node:
+                                            name: immigration
                                             examples:
                                                 - arrival
                                                 - arrivals
@@ -1645,48 +1646,48 @@ node:
                                                 - choose to come
                                                 - influx
                                                 - new refugees
-                                            name: immigration
                                             polarity: 1
                                         - node:
+                                            name: migration_returnees
                                             examples:
                                                 - returnee
                                                 - return to homeland
                                                 - returned to countries
-                                            name: migration_returnees
                                             polarity: 1
                                         - node:
+                                            name: seasonal_migration
                                             examples:
                                                 - seasonal migration
                                                 - cyclic migration
                                                 - migrant
-                                            name: seasonal_migration
                                             polarity: 1
                                 - node:
                                     name: threat
                                     children:
                                         - node:
+                                            name: exploitation
                                             examples:
                                                 - exploitation
-                                            name: exploitation
                                             polarity: -1
                                         - node:
+                                            name: physical_insecurity
                                             examples:
                                                 - insecurity
                                                 - instability
                                                 - physical insecurity
                                                 - perceived security
                                                 - dangerous
-                                            name: physical_insecurity
                                             polarity: -1
                                         - node:
+                                            name: disarmament
                                             examples:
                                                 - disarmament
-                                            name: disarmament
                                             polarity: 1
                                 - node:
                                     name: criminal
                                     children:
                                         - node:
+                                            name: crime
                                             examples:
                                                 - crime
                                                 - crimes
@@ -1706,9 +1707,9 @@ node:
                                                 - violent crime
                                                 - lawlessness
                                                 - illegal
-                                            name: crime
                                             polarity: -1
                                         - node:
+                                            name: abduction
                                             examples:
                                                 - child abductions
                                                 - abduction
@@ -1716,12 +1717,12 @@ node:
                                                 - forced recruitment
                                                 - abducted
                                                 - kidnapped
-                                            name: abduction
                                             polarity: -1
                                 - node:
                                     name: conflict
                                     children:
                                         - node:
+                                            name: tension
                                             examples:
                                                 - political tension
                                                 - political tensions
@@ -1733,9 +1734,9 @@ node:
                                                 - hardship
                                                 - burden
                                                 - threatening
-                                            name: tension
                                             polarity: -1
                                         - node:
+                                            name: hostility
                                             examples:
                                                 - conflict
                                                 - war
@@ -1759,9 +1760,9 @@ node:
                                                 - sabotage
                                                 - vandalized
                                                 - army mobilization
-                                            name: hostility
                                             polarity: -1
                                         - node:
+                                            name: demonstrate
                                             examples:
                                                 - civil unrest
                                                 - social unrest
@@ -1776,9 +1777,9 @@ node:
                                                 - turmoil
                                                 - demands
                                                 - riot
-                                            name: demonstrate
                                             polarity: -1
                                         - node:
+                                            name: war
                                             examples:
                                                 - bombard
                                                 - genocide
@@ -1800,9 +1801,9 @@ node:
                                                 - invaded
                                                 - warfare
                                                 - the outbreak of war
-                                            name: war
                                             polarity: -1
                                         - node:
+                                            name: attack
                                             examples:
                                                 - bombard
                                                 - genocide
@@ -1824,9 +1825,9 @@ node:
                                                 - invasion
                                                 - massacre
                                                 - psychological warfare
-                                            name: attack
                                             polarity: -1
                                         - node:
+                                            name: strike
                                             examples:
                                                 - bombard
                                                 - attack
@@ -1835,9 +1836,9 @@ node:
                                                 - bomb
                                                 - bombing
                                                 - explosion
-                                            name: strike
                                             polarity: -1
                                         - node:
+                                            name: terrorism
                                             examples:
                                                 - terrorism
                                                 - insurgency
@@ -1845,39 +1846,38 @@ node:
                                                 - terrorist activity
                                                 - roadside bombing
                                                 - bomb threat
-                                            name: terrorism
                                             polarity: -1
                                         - node:
+                                            name: livestock_raid
                                             examples:
                                                 - cattle raid
                                                 - livestock raid
                                                 - steal livestock
                                                 - cattle raiding
-                                            name: livestock_raid
                                             polarity: -1
                         - node:
                             name: movement
                             children:
                                 - node:
+                                    name: transport
                                     examples:
                                         - transport
                                         - transporting
                                         - transportation
                                         - delivery
-                                    name: transport
                                     polarity: 1
                                 - node:
+                                    name: evacuate_humanitarian_workers
                                     examples:
                                         - evacuate humanitarian workers
                                         - evacuated aid personnel
                                         - evacuating humanitarian
-                                    name: evacuate_humanitarian_workers
                                     polarity: -1
                                 - node:
+                                    name: animal_migration
                                     examples:
                                         - animal migration
                                         - livestock migration
-                                    name: animal_migration
                                     polarity: 1
                         - node:
                             name: agriculture
@@ -1889,44 +1889,45 @@ node:
                                             name: locust_related
                                             children:
                                                 - node:
+                                                    name: locust_eggs
                                                     examples:
                                                         - locust eggs
-                                                    name: locust_eggs
                                                     polarity: -1
                                                 - node:
+                                                    name: locust_breeding
                                                     examples:
                                                         - locust breeding
                                                         - breeding area locust
-                                                    name: locust_breeding
                                                     polarity: -1
                                                 - node:
+                                                    name: locust_hatching
                                                     examples:
                                                         - locust hatching
-                                                    name: locust_hatching
                                                     polarity: -1
                                                 - node:
                                                     name: solitary
                                                     children:
                                                         - node:
+                                                            name: solitary_hopper
                                                             examples:
                                                                 - solitarious hopper
                                                                 - solitary
                                                                 - hopper
                                                                 - immature
                                                                 - instar
-                                                            name: solitary_hopper
                                                             polarity: -1
                                                         - node:
+                                                            name: solitary_locust
                                                             examples:
                                                                 - solitary locust
                                                                 - solitarious adult locust
                                                                 - mature
-                                                            name: solitary_locust
                                                             polarity: -1
                                                 - node:
                                                     name: gregarious
                                                     children:
                                                         - node:
+                                                            name: hopper_band
                                                             patterns:
                                                                 - (hopper\s+band)|(bands?\s+of\s+hoppers)
                                                             examples:
@@ -1934,9 +1935,9 @@ node:
                                                                 - locust hopper groups
                                                                 - hopper outbreak upsurge
                                                                 - immature
-                                                            name: hopper_band
                                                             polarity: -1
                                                         - node:
+                                                            name: locust_swarm
                                                             patterns:
                                                                 - (locust\s+swarm)|(swarms?\s+of\s+locust)
                                                             examples:
@@ -1946,23 +1947,23 @@ node:
                                                                 - adult
                                                                 - locust infestation
                                                                 - locust outbreak
-                                                            name: locust_swarm
                                                             polarity: -1
                                 - node:
+                                    name: planting
                                     examples:
                                         - planting
                                         - plant
                                         - planted crops
                                         - horticulture
-                                    name: planting
                                     polarity: 1
                                 - node:
+                                    name: crop_storage
                                     examples:
                                         - store crops
                                         - granary
-                                    name: crop_storage
                                     polarity: 1
                                 - node:
+                                    name: fertilization
                                     examples:
                                         - fertilization
                                         - biofertilizers
@@ -1971,9 +1972,9 @@ node:
                                         - composts
                                         - guano
                                         - manure
-                                    name: fertilization
                                     polarity: 1
                                 - node:
+                                    name: irrigation
                                     examples:
                                         - localized irrigation
                                         - capillary irrigation
@@ -1992,14 +1993,14 @@ node:
                                         - subsurface irrigation
                                         - irrigation system
                                         - irrigation
-                                    name: irrigation
                                     polarity: 1
                                 - node:
+                                    name: pesticide
                                     examples:
                                         - pesticide
-                                    name: pesticide
                                     polarity: 1
                                 - node:
+                                    name: crop_production
                                     examples:
                                         - crop yield
                                         - harvest
@@ -2057,9 +2058,9 @@ node:
                                         - cropping
                                         - agricultural production
                                         - cultivate
-                                    name: crop_production
                                     polarity: 1
                                 - node:
+                                    name: livestock_production
                                     examples:
                                         - livestock
                                         - cattle
@@ -2072,12 +2073,12 @@ node:
                                         - livestock production
                                         - domestic animals
                                         - meat production
-                                    name: livestock_production
                                     polarity: 1
                                 - node:
                                     name: plant_disease
                                     children:
                                         - node:
+                                            name: pest_infestation
                                             examples:
                                                 - pest infestation
                                                 - armyworm
@@ -2094,29 +2095,28 @@ node:
                                                 - midges
                                                 - slugs
                                                 - pest
-                                            name: pest_infestation
                                             polarity: -1
                                 - node:
+                                    name: livestock_disease
                                     examples:
                                         - livestock disease
                                         - livestock diseases
-                                    name: livestock_disease
                                     polarity: -1
                         - node:
                             name: wild_food_sources
                             children:
                                 - node:
+                                    name: foraging_wild_foods
                                     examples:
                                         - gather gathering wild foods
                                         - forage
                                         - foraging
-                                    name: foraging_wild_foods
                                     polarity: 1
                                 - node:
+                                    name: hunting
                                     examples:
                                         - hunting
                                         - trapping
-                                    name: hunting
                                     polarity: 1
                         - node:
                             name: health_and_life
@@ -2125,58 +2125,59 @@ node:
                                     name: living_condition
                                     children:
                                         - node:
+                                            name: food_safety
                                             examples:
                                                 - food safety
-                                            name: food_safety
                                             polarity: 1
                                         - node:
+                                            name: water_safety
                                             examples:
                                                 - water safety
                                                 - unsafe water
                                                 - lack of clean water
                                                 - unpotable
-                                            name: water_safety
                                             polarity: 1
                                         - node:
+                                            name: sanitation_and_hygiene
                                             examples:
                                                 - unsanitary condition
                                                 - unclean workspaces
                                                 - unclean unsafe living conditions
-                                            name: sanitation_and_hygiene
                                             polarity: 1
                                 - node:
                                     name: nutrition
                                     children:
                                         - node:
+                                            name: food_intake
                                             examples:
                                                 - food intake
-                                            name: food_intake
                                             polarity: 1
                                         - node:
+                                            name: food_diversity
                                             examples:
                                                 - food diversity
                                                 - food variety
                                                 - nutritional variety
                                                 - nutrition
                                                 - nutritional security
-                                            name: food_diversity
                                             polarity: 1
                                         - node:
+                                            name: food_preparation
                                             examples:
                                                 - food preparation
                                                 - cooking
                                                 - meal preparation
-                                            name: food_preparation
                                             polarity: 1
                                         - node:
+                                            name: food_preference
                                             examples:
                                                 - food preference
                                                 - seed preference
                                                 - dietary preferences
                                                 - food taste choice
-                                            name: food_preference
                                             polarity: 1
                                         - node:
+                                            name: malnutrition
                                             examples:
                                                 - food gap
                                                 - malnutrition
@@ -2185,43 +2186,43 @@ node:
                                                 - nutritional deficiency
                                                 - vitamin deficiencies
                                                 - food riots
-                                            name: malnutrition
                                             polarity: -1
                                         - node:
+                                            name: breast_feeding
                                             examples:
                                                 - breast feeding
                                                 - breastfeeding
                                                 - breastfed
-                                            name: breast_feeding
                                             polarity: 1
                                 - node:
+                                    name: biometrics
                                     examples:
                                         - biometrics
                                         - fingerprint
                                         - human features
-                                    name: biometrics
                                     polarity: 1
                                 - node:
                                     name: disease
                                     children:
                                         - node:
+                                            name: transmission
                                             examples:
                                                 - transmission
                                                 - community spread
                                                 - airborne
                                                 - virus
-                                            name: transmission
                                             polarity: -1
                                         - node:
+                                            name: covid_virus
                                             patterns:
                                                 - (COVID|covid)
                                             examples:
                                                 - covid
                                                 - corona virus
                                                 - coronavirus
-                                            name: covid_virus
                                             polarity: -1
                                         - node:
+                                            name: human_disease
                                             examples:
                                                 - HIV
                                                 - malaria
@@ -2247,19 +2248,19 @@ node:
                                                 - preventable diseases
                                                 - infection
                                                 - infectious
-                                            name: human_disease
                                             polarity: 1
                                         - node:
+                                            name: alcohol_drug_and_substance_abuse
                                             examples:
                                                 - alcohol drug and substance abuse
                                                 - alcohol abuse
                                                 - drug rehabilitation
-                                            name: alcohol_drug_and_substance_abuse
                                             polarity: -1
                                 - node:
                                     name: treatment
                                     children:
                                         - node:
+                                            name: health_treatment
                                             examples:
                                                 - disease treatment
                                                 - medication
@@ -2268,9 +2269,9 @@ node:
                                                 - therapeutic treatment
                                                 - cure
                                                 - surgery
-                                            name: health_treatment
                                             polarity: 1
                                 - node:
+                                    name: death
                                     examples:
                                         - death
                                         - mortality
@@ -2284,41 +2285,41 @@ node:
                                         - suicide
                                         - deaths
                                         - murder
-                                    name: death
                                     polarity: -1
                                 - node:
+                                    name: injury
                                     examples:
                                         - injury
                                         - wounds
-                                    name: injury
                                     polarity: -1
                                 - node:
+                                    name: birth
                                     examples:
                                         - birth
                                         - childbirth
                                         - neonatal
                                         - born
-                                    name: birth
                                     polarity: 1
                                 - node:
+                                    name: basic_needs
                                     examples:
                                         - basic needs
                                         - population needs
                                         - humanitarian needs
-                                    name: basic_needs
                                     polarity: 1
                         - node:
                             name: access
                             children:
                                 - node:
+                                    name: market_access
                                     examples:
                                         - market access
-                                    name: market_access
                                     polarity: 1
                                 - node:
                                     name: infrastructure_access
                                     children:
                                         - node:
+                                            name: electrical
                                             examples:
                                                 - energy
                                                 - electric plant
@@ -2327,17 +2328,17 @@ node:
                                                 - electricity
                                                 - access to electrical services
                                                 - electrical services
-                                            name: electrical
                                             polarity: 1
                                         - node:
+                                            name: waste
                                             examples:
                                                 - waste
                                                 - sewage treatment
                                                 - sewage treatment
                                                 - garbage removal
-                                            name: waste
                                             polarity: 1
                                         - node:
+                                            name: road_access
                                             examples:
                                                 - highway access
                                                 - road network access
@@ -2345,24 +2346,24 @@ node:
                                                 - accessibility by road
                                                 - able to be reached by road
                                                 - road conditions
-                                            name: road_access
                                             polarity: 1
                                         - node:
+                                            name: bridge
                                             examples:
                                                 - bridge
-                                            name: bridge
                                             polarity: 1
                                         - node:
+                                            name: construction_materials
                                             examples:
                                                 - construction materials
                                                 - access to construction materials
                                                 - availability of building materials
-                                            name: construction_materials
                                             polarity: 1
                                         - node:
                                             name: transportation
                                             children:
                                                 - node:
+                                                    name: travel
                                                     examples:
                                                         - transit system
                                                         - public transportation
@@ -2370,25 +2371,25 @@ node:
                                                         - travel
                                                         - transit
                                                         - air services
-                                                    name: travel
                                                     polarity: 1
                                                 - node:
+                                                    name: shipping
                                                     examples:
                                                         - shipping
                                                         - freight
                                                         - cargo
-                                                    name: shipping
                                                     polarity: 1
                                         - node:
                                             name: medical
                                             children:
                                                 - node:
+                                                    name: ambulances
                                                     examples:
                                                         - ambulances
                                                         - EMS
-                                                    name: ambulances
                                                     polarity: 1
                                                 - node:
+                                                    name: medical_facility
                                                     examples:
                                                         - hospital
                                                         - clinic
@@ -2396,18 +2397,18 @@ node:
                                                         - health post
                                                         - healthcare facility availability
                                                         - access to hospitals
-                                                    name: medical_facility
                                                     polarity: 1
                                                 - node:
+                                                    name: medical_workers
                                                     examples:
                                                         - medical workers
                                                         - health workers
                                                         - doctors
                                                         - nurses nursing staff
                                                         - first responders
-                                                    name: medical_workers
                                                     polarity: 1
                                 - node:
+                                    name: water_access
                                     examples:
                                         - water insecurity
                                         - water shortage
@@ -2442,9 +2443,9 @@ node:
                                         - water pipes
                                         - water access
                                         - water supply
-                                    name: water_access
                                     polarity: 1
                         - node:
+                            name: trend
                             examples:
                                 - trend
                                 - trends
@@ -2456,54 +2457,54 @@ node:
                                 - tendency
                                 - declined
                                 - improved
-                            name: trend
                             polarity: 1
                         - node:
                             name: food_security
                             children:
                                 - node:
+                                    name: food_availability
                                     examples:
                                         - food availability
                                         - food security
                                         - good domestic food supply
                                         - availability of foods
-                                    name: food_availability
                                     opposite: wm/concept/causal_factor/food_insecurity/food_unavailability
                                     polarity: 1
                                 - node:
+                                    name: food_production
                                     examples:
                                         - food production
                                         - producing food
-                                    name: food_production
                                     polarity: 1
                                 - node:
+                                    name: food_utilization
                                     examples:
                                         - food utilization
                                         - consumption of enough food
-                                    name: food_utilization
                                     opposite: wm/concept/causal_factor/food_insecurity/food_nonutilization
                                     polarity: 1
                                 - node:
+                                    name: household_food_storage
                                     examples:
                                         - household food storage
-                                    name: household_food_storage
                                     polarity: 1
                                 - node:
+                                    name: food_access
                                     examples:
                                         - food access
-                                    name: food_access
                                     opposite: wm/concept/causal_factor/food_insecurity/food_nonaccess
                                     polarity: 1
                                 - node:
+                                    name: food_stability
                                     examples:
                                         - food stability
-                                    name: food_stability
                                     opposite: wm/concept/causal_factor/food_insecurity/food_instability
                                     polarity: 1
                         - node:
                             name: food_insecurity
                             children:
                                 - node:
+                                    name: food_unavailability
                                     examples:
                                         - food insecurity
                                         - food scarcity
@@ -2513,39 +2514,39 @@ node:
                                         - unavailability of food
                                         - food deficits
                                         - cereal shortage
-                                    name: food_unavailability
                                     opposite: wm/concept/causal_factor/food_security/food_availability
                                     polarity: -1
                                 - node:
+                                    name: food_nonutilization
                                     examples:
                                         - food wasting
                                         - food wastage
                                         - inadequate food consumption
-                                    name: food_nonutilization
                                     opposite: wm/concept/causal_factor/food_security/food_utilization
                                     polarity: -1
                                 - node:
+                                    name: food_nonaccess
                                     examples:
                                         - food nonaccess
                                         - unable to access food supplies
-                                    name: food_nonaccess
                                     opposite: wm/concept/causal_factor/food_security/food_access
                                     polarity: -1
                                 - node:
+                                    name: food_instability
                                     examples:
                                         - food instability
-                                    name: food_instability
                                     opposite: wm/concept/causal_factor/food_security/food_stability
                                     polarity: -1
                 - node:
                     name: entity
                     children:
                         - node:
+                            name: geo-location
                             examples:
                                 - geographic location
-                            name: geo-location
                             polarity: 1
                         - node:
+                            name: organization
                             examples:
                                 - commission
                                 - workshop
@@ -2556,27 +2557,27 @@ node:
                                 - programme
                                 - Programme Work
                                 - convention
-                            name: organization
                             polarity: 1
                         - node:
+                            name: government_entity
                             examples:
                                 - government entity
                                 - program entity
-                            name: government_entity
                             polarity: 1
                         - node:
                             name: person_and_group
                             children:
                                 - node:
+                                    name: population
                                     examples:
                                         - people group
                                         - people
                                         - ethnic group
                                         - population
                                         - rural
-                                    name: population
                                     polarity: 1
                                 - node:
+                                    name: community
                                     examples:
                                         - community
                                         - villages
@@ -2584,12 +2585,11 @@ node:
                                         - family
                                         - families
                                         - communities
-                                    name: community
                                     polarity: 1
                         - node:
+                            name: artifact
                             examples:
                                 - artifact
-                            name: artifact
                             polarity: 1
                 - node:
                     name: time
@@ -2598,14 +2598,15 @@ node:
                             name: temporal
                             children:
                                 - node:
+                                    name: crop_season
                                     examples:
                                         - harvest
                                         - lean season
                                         - planting season
                                         - sowing season
-                                    name: crop_season
                                     polarity: 1
                                 - node:
+                                    name: season
                                     examples:
                                         - summer
                                         - winter
@@ -2614,6 +2615,5 @@ node:
                                         - dry season
                                         - rainy season
                                         - monsoon season
-                                    name: season
                                     polarity: 1
 

--- a/wm_flat_metadata.yml
+++ b/wm_flat_metadata.yml
@@ -3,2467 +3,2617 @@
 #  - we don't attempt to differentiate "event" and "entities" but rather trying to put all causal factors into "causal_factor"
 #  - use coarse-grained concepts "causal_factor", "entity" (where the causal factor is located, who and what artifacts are involved in a causal factor), "time", and "indicator_and_reported_property" as the top level concepts.
 # - allow multiple inheritance ("economic_crisis" is a child to both "economic_and_commerce" and "crisis_and_disaster"). Concepts under "intervention" and "condition" will overlap with other categories
-- wm:
-  - concept:
-    - causal_factor:
-      - interventions:
-        - provide: # (supply, distribute, deliver, vaccinate, give)
-          - agriculture_inputs: # agricultural_productivity
-            - livestock_production_inputs:
-              - OntologyNode:
-                examples:
-                - livestock feed
-                - hay
-                - CSB
-                - silage
-                - corn meal
-                - soybean hulls
-                name: livestock_feed
-                polarity: 1
-              - OntologyNode:
-                examples:
-                - veterinary services medicine
-                - animal birthing
-                - antibiotics
-                - livestock vaccination
-                name: veterinary_services
-                polarity: 1
-              - OntologyNode:
-                examples:
-                - livestock watering
-                name: livestock_watering
-                polarity: 1
-            - crop_production_equipment:
-              - OntologyNode:
-                examples:
-                - farm equipment
-                - machinery
-                - tractor
-                - power tiller
-                - row planter
-                - plow
-                - winnower
-                name: farm_equipment
-                polarity: 1
-              - OntologyNode:
-                examples:
-                - harvesting equipment
-                - baskets
-                - pickers
-                - ladders
-                - clippers
-                name: harvesting_equipment
-                polarity: 1
-              - OntologyNode:
-                examples:
-                - seed
-                - planting
-                name: seed
-                polarity: 1
-              - irrigation_equipment:
+OntologyNode:
+    name: wm
+    children:
+        - OntologyNode:
+            name: concept
+            children:
                 - OntologyNode:
-                  examples:
-                  - water source
-                  - wells
-                  - bore-holes
-                  - irrigation ditch
-                  - canal
-                  name: water_source
-                  polarity: 1
+                    name: causal_factor
+                    children:
+                        - OntologyNode:
+                            name: interventions
+                            children:
+                                - OntologyNode:
+                                    name: provide
+                                    children:
+                                        - OntologyNode:
+                                            name: agriculture_inputs
+                                            children:
+                                                - OntologyNode:
+                                                    name: livestock_production_inputs
+                                                    children:
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - livestock feed
+                                                                - hay
+                                                                - CSB
+                                                                - silage
+                                                                - corn meal
+                                                                - soybean hulls
+                                                            name: livestock_feed
+                                                            polarity: 1
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - veterinary services medicine
+                                                                - animal birthing
+                                                                - antibiotics
+                                                                - livestock vaccination
+                                                            name: veterinary_services
+                                                            polarity: 1
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - livestock watering
+                                                            name: livestock_watering
+                                                            polarity: 1
+                                                - OntologyNode:
+                                                    name: crop_production_equipment
+                                                    children:
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - farm equipment
+                                                                - machinery
+                                                                - tractor
+                                                                - power tiller
+                                                                - row planter
+                                                                - plow
+                                                                - winnower
+                                                            name: farm_equipment
+                                                            polarity: 1
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - harvesting equipment
+                                                                - baskets
+                                                                - pickers
+                                                                - ladders
+                                                                - clippers
+                                                            name: harvesting_equipment
+                                                            polarity: 1
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - seed
+                                                                - planting
+                                                            name: seed
+                                                            polarity: 1
+                                                        - OntologyNode:
+                                                            name: irrigation_equipment
+                                                            children:
+                                                                - OntologyNode:
+                                                                    examples:
+                                                                        - water source
+                                                                        - wells
+                                                                        - bore-holes
+                                                                        - irrigation ditch
+                                                                        - canal
+                                                                    name: water_source
+                                                                    polarity: 1
+                                                                - OntologyNode:
+                                                                    examples:
+                                                                        - water pumps
+                                                                        - treadle
+                                                                        - electric pump
+                                                                        - small scale irrigation pump
+                                                                    name: pumps
+                                                                    polarity: 1
+                                                                - OntologyNode:
+                                                                    examples:
+                                                                        - field irrigation
+                                                                        - drip
+                                                                        - sprinklers
+                                                                    name: field_irrigation
+                                                                    polarity: 1
+                                                        - OntologyNode:
+                                                            name: soil_inputs
+                                                            children:
+                                                                - OntologyNode:
+                                                                    examples:
+                                                                        - fertilizer
+                                                                        - DAP
+                                                                        - urea
+                                                                        - compost
+                                                                        - manure
+                                                                        - nitrogen
+                                                                        - potassium
+                                                                        - phosphorous
+                                                                    name: fertilizer
+                                                                    polarity: 1
+                                                                - OntologyNode:
+                                                                    examples:
+                                                                        - fertilizer subsidy
+                                                                        - fertilizer voucher
+                                                                        - cash
+                                                                        - price control
+                                                                        - fertilizer coupon
+                                                                    name: fertilizer_subsidy
+                                                                    polarity: 1
+                                                        - OntologyNode:
+                                                            name: weed_pest_control
+                                                            children:
+                                                                - OntologyNode:
+                                                                    examples:
+                                                                        - biological pest weed control
+                                                                        - crop rotation
+                                                                        - cover crop
+                                                                        - integrated pest management
+                                                                        - IPM
+                                                                        - companion planting
+                                                                    name: biological
+                                                                    polarity: 1
+                                                                - OntologyNode:
+                                                                    patterns:
+                                                                        - \b(DDT|dicamba|round-up)\b
+                                                                    examples:
+                                                                        - chemical pest weed control
+                                                                        - glysophate
+                                                                        - round-up
+                                                                        - dicamba
+                                                                        - DDT
+                                                                    name: chemical
+                                                                    polarity: 1
+                                                                - OntologyNode:
+                                                                    examples:
+                                                                        - organic pest weed control
+                                                                        - vinegar
+                                                                        - pine oil
+                                                                        - neem oil
+                                                                    name: organic
+                                                                    polarity: 1
+                                                - OntologyNode:
+                                                    name: post_harvest_inputs
+                                                    children:
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - harvest processing equipment
+                                                                - thresher
+                                                                - sorter
+                                                                - washer
+                                                                - drier
+                                                                - x-ray
+                                                                - harvest laser sorter
+                                                                - tarp
+                                                                - harvest drier racks
+                                                            name: processing_equipment
+                                                            polarity: 1
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - harvest packaging
+                                                                - packing lines
+                                                                - branding
+                                                                - packaging material
+                                                            name: packaging
+                                                            polarity: 1
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - warehousing
+                                                                - warehouse receipt system
+                                                                - WRS
+                                                                - storage
+                                                            name: warehousing
+                                                            polarity: 1
+                                        - OntologyNode:
+                                            name: information_services
+                                            children:
+                                                - OntologyNode:
+                                                    patterns:
+                                                        - \b(IPC|FEWS|VAM)\b
+                                                        - \bearly\s+warning\s+system\b
+                                                    examples:
+                                                        - surveillance system
+                                                        - early warning systems
+                                                        - earthquake monitoring
+                                                        - food security monitoring
+                                                        - early warning analysis
+                                                        - famine early warning system
+                                                        - integrated phase classification
+                                                        - IPC
+                                                        - FEWS NET
+                                                        - vulnerability analysis mapping
+                                                        - VAM
+                                                    name: surveillance_system
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - weather monitoring
+                                                    name: weather_monitoring
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - price monitoring
+                                                    name: price_monitoring
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    name: human_rights_monitoring
+                                                    children:
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - victims
+                                                                - children victims
+                                                                - women victims
+                                                                - refugees
+                                                                - IDP
+                                                                - ethnic minorities
+                                                            name: victims
+                                                            polarity: 1
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - perpetrators
+                                                                - militias
+                                                                - gangs
+                                                                - terrorist groups
+                                                                - non state actors
+                                                            name: perpetrators
+                                                            polarity: 1
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - violations
+                                                                - human rights violations crimes
+                                                                - war crimes
+                                                                - gender based violence
+                                                                - GBV
+                                                            name: violations
+                                                            polarity: 1
+                                                - OntologyNode:
+                                                    name: statistics
+                                                    children:
+                                                        - OntologyNode:
+                                                            patterns:
+                                                                - \b(census|AgSS|CFSVA)\b
+                                                            examples:
+                                                                - survey
+                                                                - Census
+                                                                - DHS
+                                                                - demographic health surveys
+                                                                - CFSVA
+                                                                - comprehensive food security and vulnerability assessment
+                                                                - AgSS
+                                                                - agricultural sample survey
+                                                            name: national_survey
+                                                            polarity: 1
+                                        - OntologyNode:
+                                            name: livelihood_support
+                                            children:
+                                                - OntologyNode:
+                                                    examples:
+                                                        - food aid
+                                                        - food for work
+                                                        - food for assets
+                                                        - food for training
+                                                        - food vouchers
+                                                        - free food distribution
+                                                        - school feeding
+                                                    name: food_aid
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - nutrition support
+                                                        - food fortification
+                                                        - infant nutrition supplements
+                                                        - infant and young child feeding
+                                                        - micro nutrient supplementation
+                                                        - supplementary feeding
+                                                    name: nutrition_support
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - water
+                                                        - water trucking
+                                                    name: water
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - financial assistance
+                                                        - cash
+                                                        - loans
+                                                        - cash for assets
+                                                        - cash for work
+                                                        - cash transfer
+                                                        - once off cash transfer to facilitate return
+                                                        - grants
+                                                        - remittances
+                                                    name: financial_assistance
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - livelihood assets
+                                                        - fishing nets
+                                                        - boats
+                                                        - farming equipment
+                                                        - bee keeping equipment
+                                                        - improved chicken breed
+                                                        - bicycle
+                                                        - cart
+                                                    name: livelihood_assets
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    name: humanitarian_nonfood_items
+                                                    children:
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - shelter
+                                                                - tents
+                                                                - shelter kits
+                                                            name: shelter
+                                                            polarity: 1
+                                        - OntologyNode:
+                                            name: medical_inputs
+                                            children:
+                                                - OntologyNode:
+                                                    patterns:
+                                                        - \b(immuniz(ations?|e))\b
+                                                    examples:
+                                                        - vaccine
+                                                        - vaccination
+                                                        - immunization
+                                                        - communicable disease outbreak control
+                                                        - mass vaccination campaign
+                                                        - polio
+                                                        - measles
+                                                        - yellow fever
+                                                    name: vaccine
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - medical treatment
+                                                        - anti retroviral treatment
+                                                        - ART
+                                                        - first aid
+                                                        - basic medical care
+                                                        - childhood essential health services
+                                                        - obstetric and newborn care
+                                                        - operation of mobile clinics
+                                                        - therapeutic feeding
+                                                        - trauma and surgical care
+                                                        - trauma and post operative rehabilitation
+                                                    name: medical_treatment
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - prevention
+                                                        - insecticide treated bednets
+                                                        - malnutrition screening
+                                                        - preventative medicine
+                                                        - well-child visit
+                                                        - well-visit
+                                                    name: prevention
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - psychological
+                                                        - therapy
+                                                        - clinical management of sexual violence
+                                                        - psychological support
+                                                        - therapist counselor
+                                                    name: psychological
+                                                    polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - sanitation and hygiene input
+                                                - desludging
+                                                - toilet
+                                                - septic tank
+                                                - excreta container
+                                                - solid waste management
+                                                - point of use water treatment
+                                                - piped water supply treatment
+                                            name: sanitation_and_hygiene_inputs
+                                            polarity: 1
+                                - OntologyNode:
+                                    name: build
+                                    children:
+                                        - OntologyNode:
+                                            name: agriculture_infrastructure
+                                            children:
+                                                - OntologyNode:
+                                                    name: livestock_production_infrastructure
+                                                    children:
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - enclosure
+                                                                - barn
+                                                                - pasture
+                                                                - livestock shelter
+                                                                - paddock
+                                                                - chicken coop
+                                                                - coop
+                                                            name: livestock_shelter # enclosure, barn, pasture, etc
+                                                            polarity: 1
+                                                - OntologyNode:
+                                                    name: crop_production_infrastructure
+                                                    children:
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - canal
+                                                                - reservoir
+                                                                - water tower
+                                                                - standpipe
+                                                                - irrigation infrastructure
+                                                            name: irrigation_infrastructure # canal, reservoir, water_tower
+                                                            polarity: 1
+                                                        - OntologyNode:
+                                                            patterns:
+                                                                - \bextension\s+offices?
+                                                            examples:
+                                                                - farmer training center
+                                                                - demonstration plot
+                                                                - extension office
+                                                            name: extension_offices # farmer_training_centers, demonstration plots, etc
+                                                            polarity: 1
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - nursery
+                                                                - plant nursery
+                                                                - greenhouse
+                                                                - high tunnel
+                                                                - glasshouse
+                                                                - hothouse
+                                                            name: greenhouse # nursery, high_tunnel, etc.
+                                                            polarity: 1
+                                                        - OntologyNode:
+                                                            patterns:
+                                                                - \b(tower|bunker|stave|grain)\b\s(silo)
+                                                            examples:
+                                                                - on-farm processing facility
+                                                                - silo
+                                                                - tower silo
+                                                                - bunker silo
+                                                                - stave silo
+                                                                - grain silo
+                                                                - grain elevator
+                                                                - cooperative processing
+                                                                - post-harvest
+                                                            name: post_harvest_infrastructure # on-farm_processing_facility, silos, cooperative_processing, storage, etc.
+                                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - factory
+                                                - industrial park
+                                                - storage facility
+                                                - warehouse
+                                                - processing facility
+                                                - trade infrastructure
+                                            name: trade_infrastructure # factory, industrial_park, storage_facilities, warehouse, processing_facilities, etc.
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - community center
+                                                - classroom
+                                                - child friendly learning space
+                                                - school rehabilitation
+                                                - gender-specific bathrooms
+                                                - educational infrastructure
+                                                - school infrastructure
+                                            name: educational_infrastructure # community_centers, child_friendly_learning_spaces, school_rehabilitation, gender_specific_bathrooms, etc.
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - permanent house
+                                                - temporary housing
+                                                - refugee camp
+                                                - housing provision
+                                                - leasing or rental services
+                                                - temporary communal settlement
+                                                - temporary shelter
+                                                - portable shelter
+                                                - shelter
+                                            name: shelter_housing # permanent_house, temporary_housing, refugee_camp, housing_provision, leasing_or_rental_services, temporary_communal_settlement, etc.
+                                            polarity: 1
+                                        - OntologyNode:
+                                            patterns:
+                                                - \b(WASH)\binfrastructure
+                                            examples:
+                                                - sanitation facility
+                                                - latrine
+                                                - washing and bathing facility
+                                                - temporary water points
+                                                - borehole
+                                                - permanent water point
+                                                - borehole repair
+                                                - WASH infrastructure
+                                            name: WASH_infrastructure # sanitation facilities, latrines, washing_and_bathing_facilities, temporary_water_points, boreholes, permanent_water_points, borehole_repair, etc.
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - hospital
+                                                - mobile clinic
+                                                - field hospital
+                                                - triage
+                                                - emergency treatment center
+                                                - emergency treatment centre
+                                                - medical supply chain facility
+                                                - medical infrastructure
+                                            name: medical_infrastructure # hospitals, mobile clinics, field_hospitals, emergency treatment centers, medical supply chain facilities, etc.
+                                            polarity: 1
+                                        - OntologyNode:
+                                            patterns:
+                                                - \b(road|bridge|rail)\s(repair)
+                                            examples:
+                                                - bridge
+                                                - all weather roads
+                                                - railway lines
+                                                - temporary roads
+                                                - road rehabilitation
+                                                - road repair
+                                                - transportation infrastructure
+                                            name: transportation_infrastructure # bridge, repair, all_weather_roads, railway_lines, temporary_roads, road_rehabilitation
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - internet access service
+                                                - cell-phone tower
+                                                - cell tower
+                                                - landline
+                                                - phone line
+                                                - telephone pole
+                                                - telepole
+                                                - communication infrastructure
+                                            name: communication_infrastructure # cell-phone_towers, landlines, etc
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - dam
+                                                - electricity grid
+                                                - electric grid
+                                                - power grid
+                                                - micro-grid
+                                                - solar panel
+                                                - wind turbine
+                                                - wind farm
+                                                - solar farm
+                                                - energy infrastructure
+                                            name: energy_infrastructure # dams, electricity_grids, micro-grids, solar_panels, wind_turbines, wind_farms, solar_farms, etc.
+                                            polarity: 1
+                                - OntologyNode:
+                                    name: train
+                                    children:
+                                        - OntologyNode:
+                                            name: agriculture_training
+                                            children:
+                                                - OntologyNode:
+                                                    name: production_practices
+                                                    children:
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - cover cropping
+                                                                - composting
+                                                                - planting practices
+                                                                - training
+                                                            name: planting_training # crop_spacing, planting_times, seed_depth, watering, crop_rotation, cover_cropping, composting, low_till, no_till, perennial_planting, Conservation_agriculture
+                                                            polarity: 1
+                                                        - OntologyNode:
+                                                            patterns:
+                                                                - (\bIPM\b)(\s(practices))?
+                                                            examples:
+                                                                - training IPM practices
+                                                                - training integrated pest management
+                                                                - training pest control
+                                                                - weed control
+                                                            name: pest_weed_control # IPM_practices (integrated pest management), etc
+                                                            polarity: 1
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - training storage
+                                                                - training processing
+                                                                - training packaging
+                                                                - training safety and hygiene
+                                                                - certifications
+                                                                - ISO
+                                                                - FDA
+                                                                - workplace safety
+                                                                - post-harvest practices
+                                                            name: post_harvest_practices # storage, processing, packaging, safety_and_hygiene, certifications, ISO, FDA, work_place_safety, etc.
+                                                            polarity: 1
+                                                - OntologyNode:
+                                                    patterns:
+                                                        - (\bNM[AS]\b)\s(reports?)
+                                                    examples:
+                                                        - farmer's almanac
+                                                        - weather information
+                                                        - national weather service meteorological met
+                                                        - agriculture information
+                                                    name: agriculture_information # digital_extension, famers_almanac, mobile_extension, SMS reminders,  Weather_information,  NMA_reports (national met agency), broadcast_weather_reports,
+                                                    polarity: 1
+                                        - OntologyNode:
+                                            name: medical_training
+                                            children:
+                                                - OntologyNode:
+                                                    examples:
+                                                        - medical training
+                                                        - assessment of health facilities
+                                                        - triage of health facilities
+                                                        - evaluation community health workers
+                                                        - CHWs
+                                                        - medical capacity assessment
+                                                    name: assessment_and_triage_of_health_facilities
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - capacity building of medical staff
+                                                        - medical capacity building
+                                                    name: capacity_building_of_medical_staff
+                                                    polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - human rights training
+                                            name: human_rights_training
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - provision of credit
+                                                - training for income generation
+                                                - training credit provision
+                                                - income generation training
+                                                - financial management
+                                            name: financial_management # provision_of_credit_and_training_for_income_generation
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - provision of non-formal education
+                                                - training community sourced temporary teachers
+                                                - education systems
+                                                - capacity building of educational staff
+                                                - training education capacity building
+                                            name: education_systems #  provision_of_non_formal_education, community_sourced_temporary_teachers
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - behavior change campaign
+                                                - behaviour change campaign
+                                                - public health information
+                                                - hygiene promotion
+                                                - health information campaign
+                                                - health promotors
+                                                - health promotion
+                                                - public health campaigns
+                                            name: public_health_campaigns # behaviour change, campaigns, public information, hygiene_promotion, information_campaign, health_promoters,
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - explosive hazards campaign
+                                                - public safety campaigns
+                                            name: public_safety_campaigns # explosive_hazards
+                                            polarity: 1
+                                        - OntologyNode:
+                                            name: emergency_preparedness_training
+                                            children:
+                                                - OntologyNode:
+                                                    examples:
+                                                        - surveillance system strengthening
+                                                    name: surveillance_system_strengthening
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - SPHERE
+                                                        - core standards
+                                                        - humanitarian charter
+                                                        - humanitarian certifications
+                                                    name: humanitarian_certifications # SPHERE, core_standards, humanitarian_charter, etc.
+                                                    polarity: 1
+                                - OntologyNode:
+                                    name: secure
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - agricultural assets
+                                                - cattle raid
+                                                - supply chain
+                                                - livelihood protections
+                                                - defend livelihood
+                                                - protect livelihood
+                                                - stabilize livelihood
+                                                - conserve livelihood
+                                                - neutralize threat to livelihood
+                                                - preserve livelihood
+                                                - secure livelihood
+                                            name: livelihood_protections #  agricultural assets, cattle_raids, supply chains,
+                                            polarity: 1
+                                        - OntologyNode:
+                                            name: community_security
+                                            children:
+                                                - OntologyNode:
+                                                    examples:
+                                                        - mine clearance
+                                                        - demining
+                                                        - remove land mines
+                                                        - clear land mines
+                                                        - neutralize land mines
+                                                    name: mine_clearance
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - temporary policing services
+                                                        - temporary police
+                                                        - temporary security services
+                                                        - security escort
+                                                    name: temporary_policing_services
+                                                    polarity: 1
+                                        - OntologyNode:
+                                            patterns:
+                                                - peace\s+(building|talks)
+                                                - conflict\s+resolution
+                                            examples:
+                                                - conflict mediation
+                                                - political dialogue
+                                                - disarmament
+                                                - demobilization
+                                                - reintegration
+                                                - family reunification
+                                                - rehabilitation of child soldiers
+                                                - conflict resolution
+                                            name: conflict_resolution # conflict_mediation, political_dialogue, disarmament, demobilization, reintegration, family_reunification, rehabilitation_of_child_soldier
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - water rights
+                                                - land rights
+                                                - land deeds
+                                                - biotechnology
+                                                - defend natural resources
+                                                - protect natural resources
+                                                - stabilize natural resources
+                                                - conserve natural resources
+                                                - neutralize threat to natural resources
+                                                - preserve natural resources
+                                                - secure natural resources
+                                            name: secure_natural_resources # Water_rights, Land_rights, land_deeds, Biotechnology, etc.
+                                            polarity: 1
+                                        - OntologyNode:
+                                            patterns:
+                                                - \bUNESCO\b\sworld\sheritage\ssite
+                                            examples:
+                                                - landmark designation conservation
+                                                - world heritage status site
+                                                - cultural resources protections
+                                            name: cultural_resources # landmark_designation, world_heritage_status, etc.
+                                            polarity: 1
+                                - OntologyNode:
+                                    name: legislate
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - subsidize
+                                                - subsidies
+                                                - subsidy
+                                            name: subsidize
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - tax
+                                                - taxation
+                                                - taxes
+                                                - tax legislation
+                                                - duty
+                                                - tariff
+                                            name: tax
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - control prices
+                                                - price control
+                                                - regulate prices
+                                                - legislate prices
+                                                - price ceiling
+                                                - price floor
+                                            name: control_prices
+                                            polarity: 1
+                        - OntologyNode:
+                            name: environmental
+                            children:
+                                - OntologyNode:
+                                    name: meteorologic
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - weather
+                                                - weather systems
+                                                - rains
+                                                - rainfall
+                                                - extreme winds
+                                                - wet
+                                                - wetter
+                                                - climate variability
+                                                - snow
+                                                - humid
+                                            name: weather
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - climate
+                                                - tropical
+                                                - equatorial
+                                            name: climate
+                                            polarity: 1
+                                        - OntologyNode:
+                                            name: precipitation
+                                            children:
+                                                - OntologyNode:
+                                                    examples:
+                                                        - rainfall
+                                                        - precipitation
+                                                        - rains
+                                                        - rain
+                                                    name: rainfall
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - storm
+                                                        - seasonal monsoon
+                                                        - extreme weather
+                                                    name: storm
+                                                    polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - temperature
+                                                - cooler
+                                                - cooling
+                                                - cold
+                                                - freezing
+                                                - heat
+                                                - heatwave
+                                                - record highs
+                                                - warmer
+                                                - warming
+                                            name: temperature # temperature of ...
+                                            polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - environment
+                                    name: environment
+                                    polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - climate change mitigation
+                                        - climate change adaptation
+                                    name: climate_change_mitigation
+                                    polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - conservation
+                                        - sustainable use
+                                        - biodiversity conservation
+                                        - forest management
+                                        - water management
+                                        - management forest
+                                        - depleted resources
+                                        - overexploitation
+                                    name: resource_management
+                                    polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - afforestation
+                                        - agroforestry
+                                        - forest management
+                                        - reforestation
+                                        - forestry
+                                        - logging
+                                    name: forestry
+                                    polarity: 1
+                                - OntologyNode:
+                                    name: natural_resources
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - water
+                                                - sea
+                                                - river
+                                                - pond
+                                                - water resource
+                                                - lake
+                                                - freshwater
+                                                - surface water
+                                                - groundwater
+                                                - snow melt
+                                                - water body
+                                                - reservoir
+                                            name: water_bodies
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - land availability
+                                                - availability of cropland
+                                            name: land_availability
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - fossil fuels
+                                                - coal
+                                                - oil
+                                                - natural gas
+                                            name: fossil_fuels
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - soil
+                                                - soil quality
+                                                - leaching into the soil
+                                            name: soil
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - pastoral conditions
+                                                - pasture conditions
+                                                - rangeland conditions
+                                                - vegetation conditions
+                                                - grazing conditions
+                                            name: pasture
+                                            polarity: 1
+                                - OntologyNode:
+                                    name: pollution
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - pollution
+                                                - greenhouse gas emission
+                                                - ghg emission
+                                            name: air_pollution
+                                            polarity: -1
+                                        - OntologyNode:
+                                            examples:
+                                                - contaminant
+                                                - contamination
+                                                - contaminated
+                                                - soil pollution
+                                                - soil erosion
+                                                - pollutants
+                                                - pollution
+                                                - leakage
+                                                - acidification
+                                            name: land_pollution
+                                            polarity: -1
+                                        - OntologyNode:
+                                            examples:
+                                                - deforestation
+                                                - desertification
+                                                - climate change
+                                            name: climate_change
+                                            polarity: -1
+                        - OntologyNode:
+                            name: crisis_and_disaster
+                            children:
+                                - OntologyNode:
+                                    name: health
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - disease outbreak
+                                                - global pandemic
+                                                - pandemic
+                                                - epidemic
+                                            name: pandemic
+                                            polarity: -1
+                                        - OntologyNode:
+                                            name: mitigation
+                                            children:
+                                                - OntologyNode:
+                                                    examples:
+                                                        - sanitation
+                                                        - hygiene materials
+                                                        - soap
+                                                        - wash hands
+                                                    name: sanitation
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    patterns:
+                                                        - (contact tracing)
+                                                    examples:
+                                                        - contact tracing
+                                                    name: contact_tracing
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    patterns:
+                                                        - (quarantin|shelter[- ]in[- ]place)
+                                                    examples:
+                                                        - quarantine
+                                                        - shelter in place
+                                                        - isolation
+                                                        - restrict movements
+                                                    name: quarantine
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    patterns:
+                                                        - (social distancing)
+                                                    examples:
+                                                        - social distancing
+                                                    name: social_distancing
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - masks
+                                                        - mask requirements
+                                                        - wearing face coverings
+                                                    name: masks
+                                                    polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - famine
+                                        - hunger
+                                        - starvation
+                                        - inadequate food consumption
+                                        - food deprivation
+                                        - severe food insecurity
+                                        - global acute malnutrition
+                                        - acute malnutrition
+                                    name: famine
+                                    polarity: -1
+                                - OntologyNode:
+                                    examples:
+                                        - crisis
+                                        - crises
+                                        - emergency
+                                        - disasters
+                                        - catastrophe
+                                    name: crisis
+                                    polarity: -1
+                                - OntologyNode:
+                                    name: economic
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - economic crisis
+                                                - financial crisis
+                                                - economic volatility
+                                            name: economic_crisis
+                                            polarity: -1
+                                - OntologyNode:
+                                    name: environmental_disasters
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - crop failure
+                                                - loss of crops
+                                                - decimated crop yields
+                                            name: crop_failure
+                                            polarity: -1
+                                        - OntologyNode:
+                                            examples:
+                                                - insect infestation
+                                            name: insect_infestation
+                                            polarity: -1
+                                        - OntologyNode:
+                                            name: natural_disaster
+                                            children:
+                                                - OntologyNode:
+                                                    examples:
+                                                        - flood
+                                                        - floods
+                                                        - flooding
+                                                        - flash flood
+                                                    name: flooding
+                                                    polarity: -1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - avalanche
+                                                    name: avalanche
+                                                    polarity: -1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - wildfire
+                                                    name: wildfire
+                                                    polarity: -1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - volcanic eruption
+                                                    name: volcanic_eruption
+                                                    polarity: -1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - drought
+                                                        - droughts
+                                                        - low rainfall
+                                                    name: drought
+                                                    polarity: -1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - earthquake
+                                                    name: earthquake
+                                                    polarity: -1
+                                        - OntologyNode:
+                                            name: weather_issue
+                                            children:
+                                                - OntologyNode:
+                                                    examples:
+                                                        - cold temperature
+                                                        - frigid conditions
+                                                        - blizzard
+                                                        - arctic winds
+                                                        - winter emergency
+                                                        - state of emergency due to cold weather
+                                                    name: cold_temperature
+                                                    polarity: -1
+                                        - OntologyNode:
+                                            examples:
+                                                - fire
+                                                - blaze
+                                                - wildfires
+                                                - burned
+                                            name: fire # what is on fire?
+                                            polarity: -1
+                        - OntologyNode:
+                            name: economic_and_commerce
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - poverty
+                                        - poor
+                                    name: poverty
+                                    polarity: -1
+                                - OntologyNode:
+                                    name: economic_activity
+                                    children:
+                                        - OntologyNode:
+                                            name: livelihood
+                                            children:
+                                                - OntologyNode:
+                                                    examples:
+                                                        - farming
+                                                    name: farming
+                                                    polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - currency
+                                                - dollar
+                                                - pound
+                                                - cash
+                                                - money
+                                                - hard currency
+                                                - foreign exchange
+                                            name: currency
+                                            polarity: 1
+                                        - OntologyNode:
+                                            name: cross_border_trade
+                                            children:
+                                                - OntologyNode:
+                                                    name: import
+                                                    children:
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - imported foods
+                                                                - crop imports
+                                                                - food import
+                                                                - food imports
+                                                                - imports of staples
+                                                                - international crop trade
+                                                                - food trade between countries
+                                                            name: food_import # thing imported
+                                                            polarity: 1
+                                                - OntologyNode:
+                                                    name: export
+                                                    children:
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - crop exports
+                                                                - food exports
+                                                                - exported foods
+                                                                - food exports
+                                                                - exports of staples
+                                                                - international crop trade
+                                                                - food trade between countries
+                                                            name: food_export # thing exported
+                                                            polarity: 1
+                                        - OntologyNode:
+                                            name: market
+                                            children:
+                                                - OntologyNode:
+                                                    examples:
+                                                        - labor market
+                                                        - labour market
+                                                        - employees
+                                                        - hiring
+                                                        - employment
+                                                        - recruit
+                                                        - find work
+                                                    name: labor_market
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - fuel
+                                                        - biofuel
+                                                        - petroleum production
+                                                        - gas
+                                                        - oil
+                                                        - demand for oil
+                                                        - oil markets
+                                                        - crude
+                                                        - crude market
+                                                        - petrol
+                                                        - diesel
+                                                        - oil production
+                                                    name: fuel
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    name: price_or_cost
+                                                    children:
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - food price
+                                                                - food prices
+                                                                - crop price
+                                                                - food cost
+                                                                - staple prices
+                                                                - staple food price
+                                                                - cost of food
+                                                                - wheat prices
+                                                                - cost of maize
+                                                                - rising cost of food
+                                                                - price of soy
+                                                                - rice prices
+                                                                - high food prices
+                                                                - grain cost
+                                                            name: food_price
+                                                            polarity: 1
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - bamboo prices
+                                                                - banana prices
+                                                                - barley prices
+                                                                - bean prices
+                                                                - beans prices
+                                                                - cassava prices
+                                                                - cereal prices
+                                                                - cereals prices
+                                                                - cocoa prices
+                                                                - coconut prices
+                                                                - coffee prices
+                                                                - corn prices
+                                                                - crop prices
+                                                                - cultivar prices
+                                                                - flux prices
+                                                                - flour prices
+                                                                - grain prices
+                                                                - groundnut prices
+                                                                - groundnuts prices
+                                                                - legume prices
+                                                                - maize prices
+                                                                - mango prices
+                                                                - meher prices
+                                                                - millet prices
+                                                                - oats prices
+                                                                - oilseed prices
+                                                                - onion prices
+                                                                - pepper prices
+                                                                - potato prices
+                                                                - rice prices
+                                                                - rubber prices
+                                                                - seed prices
+                                                                - sesame prices
+                                                                - sorghum prices
+                                                                - soybean prices
+                                                                - staple prices
+                                                                - sugar prices
+                                                                - tea prices
+                                                                - tobacco prices
+                                                                - tomato prices
+                                                                - tuber prices
+                                                                - vegetable prices
+                                                                - wheat prices
+                                                                - white maize prices
+                                                            name: crop_price
+                                                            polarity: 1
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - oil price
+                                                                - cost of crude oil
+                                                            name: oil_price
+                                                            polarity: 1
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - cost of living
+                                                                - rent
+                                                                - housing cost
+                                                            name: cost_of_living
+                                                            polarity: 1
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - cost of transportation
+                                                                - rising transit costs
+                                                                - fuel prices
+                                                            name: cost_of_transportation
+                                                            polarity: 1
+                                                - OntologyNode:
+                                                    name: revenue
+                                                    children:
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - household income
+                                                                - take home pay
+                                                                - wages
+                                                                - compensation
+                                                            name: household_income
+                                                            polarity: 1
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - farmer income
+                                                                - seasonal income
+                                                            name: farmer_income
+                                                            polarity: 1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - budget
+                                                        - budgetary constraints
+                                                        - fiscal deficits
+                                                    name: budget
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - assets
+                                                        - property
+                                                        - land assets
+                                                    name: assets
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    name: supply
+                                                    children:
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - food supply
+                                                                - market supply of crops
+                                                                - maize supply
+                                                                - domestic food supplies
+                                                                - supplies of food crops
+                                                            name: food_supply
+                                                            polarity: 1
+                                                - OntologyNode:
+                                                    name: demand
+                                                    children:
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - food demand
+                                                                - maize demand
+                                                                - market demand for crops
+                                                            name: food_demand
+                                                            polarity: 1
+                                                - OntologyNode:
+                                                    name: transaction
+                                                    children:
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - oil transaction
+                                                                - purchasing crude oil
+                                                                - oil trade
+                                                                - selling barrels
+                                                            name: oil_transaction
+                                                            polarity: 1
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - purchasing food
+                                                            name: food_purchase
+                                                            polarity: 1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - depreciation
+                                                        - depreciating
+                                                        - devaluation
+                                                        - decreased in value
+                                                    name: depreciation
+                                                    polarity: -1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - inflation
+                                                        - hyperinflation
+                                                        - inflationary pressure
+                                                    name: inflation
+                                                    polarity: -1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - currency devaluation
+                                                        - devaluate
+                                                        - currency devalued
+                                                    name: currency_devaluation
+                                                    polarity: -1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - food stocks
+                                                        - food reserves
+                                                        - grain storage
+                                                        - food reserves
+                                                        - grain reserves
+                                                        - food emergency reserves
+                                                        - price stabilization reserves
+                                                    name: food_stocks
+                                                    polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - business competition
+                                                - competitors
+                                                - industry rivalry
+                                                - competition for resources
+                                                - economic competition
+                                                - market pressure
+                                            name: competition # between? about?
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - development
+                                                - economic development
+                                                - rural development
+                                                - agricultural development
+                                            name: development # being developed
+                                            polarity: 1
+                        - OntologyNode:
+                            name: research_development
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - novel new technology
+                                        - research innovation
+                                        - breakthrough technology
+                                    name: technology_and_innovation
+                                    polarity: 1
+                        - OntologyNode:
+                            name: social_and_political
+                            children:
+                                - OntologyNode:
+                                    name: communication
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - planning
+                                                - develop plans
+                                            name: planning
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - discussion
+                                                - debate
+                                                - communication
+                                                - discourse
+                                                - dialogue
+                                            name: discussion_debate
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - collaboration
+                                                - collaborate
+                                                - partnership
+                                                - partner
+                                                - pact
+                                                - consortium
+                                            name: collaboration
+                                            polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - basic services
+                                        - primary services
+                                        - essential services
+                                    name: basic_services
+                                    polarity: 1
+                                - OntologyNode:
+                                    name: population_group
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - population density
+                                                - local population
+                                            name: population_density
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - depopulation
+                                                - de-population
+                                            name: de-population
+                                            polarity: -1
+                                        - OntologyNode:
+                                            examples:
+                                                - overcrowding
+                                                - over-crowding
+                                                - population density
+                                            name: overcrowding
+                                            polarity: -1
+                                - OntologyNode:
+                                    name: educational
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - literacy
+                                                - education
+                                                - school
+                                                - teacher training
+                                                - teacher
+                                                - classroom
+                                                - school leadership
+                                                - access to education
+                                            name: education
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - educational materials
+                                                - reading materials
+                                                - teaching aids
+                                                - classroom supplies
+                                                - school supplies
+                                            name: educational_materials
+                                            polarity: 1
+                                - OntologyNode:
+                                    name: government
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - census
+                                                - survey
+                                            name: census
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - regulation
+                                                - governance
+                                                - enforcement
+                                                - law
+                                                - policy
+                                                - legislation
+                                                - policies
+                                            name: regulation # topic
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - tax duty
+                                                - taxes
+                                                - taxation
+                                                - tariffs
+                                                - tariff
+                                                - export taxes
+                                                - excise
+                                            name: tax_duty
+                                            polarity: 1
+                                - OntologyNode:
+                                    name: political
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - political instability
+                                                - power struggle
+                                                - regime breakdown
+                                                - political violence
+                                                - unrest
+                                            name: political_instability
+                                            polarity: -1
+                                        - OntologyNode:
+                                            examples:
+                                                - corruption
+                                                - fraud
+                                                - fraudulency
+                                                - bribery
+                                                - extortion
+                                                - nepotism
+                                            name: corruption
+                                            polarity: -1
+                                        - OntologyNode:
+                                            examples:
+                                                - independence
+                                                - self-rule
+                                                - political independence
+                                            name: independence
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - sanction
+                                                - economic sanctions
+                                                - diplomatic sanctions
+                                                - sanctioned
+                                            name: sanction
+                                            polarity: -1
+                                - OntologyNode:
+                                    name: migration
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - migration
+                                                - displacement
+                                                - displaced
+                                                - evicted
+                                                - flee
+                                                - fled
+                                                - relocate
+                                                - migrate
+                                                - refugee migration
+                                                - residence move
+                                                - movement trends
+                                                - refugee
+                                                - refugees
+                                                - refugee population
+                                                - IDPs
+                                                - human displacement
+                                            name: human_migration
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - hosting IDPs
+                                                - internal displacement
+                                                - host internally displaced persons
+                                                - host refugees
+                                                - host migrants
+                                            name: hosting_idps
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - emigration
+                                                - leaving
+                                                - leave the country
+                                                - flight
+                                                - flee
+                                                - fleeing
+                                                - fled
+                                                - refugees from countries
+                                            name: emigration
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - arrival
+                                                - arrivals
+                                                - arrive in the country
+                                                - immigration
+                                                - immigrate
+                                                - choose to come
+                                                - influx
+                                                - new refugees
+                                            name: immigration
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - returnee
+                                                - return to homeland
+                                                - returned to countries
+                                            name: migration_returnees
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - seasonal migration
+                                                - cyclic migration
+                                                - migrant
+                                            name: seasonal_migration
+                                            polarity: 1
+                                - OntologyNode:
+                                    name: threat
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - exploitation
+                                            name: exploitation
+                                            polarity: -1
+                                        - OntologyNode:
+                                            examples:
+                                                - insecurity
+                                                - instability
+                                                - physical insecurity
+                                                - perceived security
+                                                - dangerous
+                                            name: physical_insecurity
+                                            polarity: -1
+                                        - OntologyNode:
+                                            examples:
+                                                - disarmament
+                                            name: disarmament
+                                            polarity: 1
+                                - OntologyNode:
+                                    name: criminal
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - crime
+                                                - crimes
+                                                - criminal
+                                                - bribery
+                                                - cybercrimes
+                                                - murdered
+                                                - sexual abuse
+                                                - assault
+                                                - stealing
+                                                - stolen
+                                                - looted
+                                                - looting
+                                                - theft
+                                                - riots
+                                                - violations
+                                                - violent crime
+                                                - lawlessness
+                                                - illegal
+                                            name: crime
+                                            polarity: -1
+                                        - OntologyNode:
+                                            examples:
+                                                - child abductions
+                                                - abduction
+                                                - kidnapping
+                                                - forced recruitment
+                                                - abducted
+                                                - kidnapped
+                                            name: abduction
+                                            polarity: -1
+                                - OntologyNode:
+                                    name: conflict
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - political tension
+                                                - political tensions
+                                                - adversity
+                                                - political instability
+                                                - stress
+                                                - distress
+                                                - challenge
+                                                - hardship
+                                                - burden
+                                                - threatening
+                                            name: tension
+                                            polarity: -1
+                                        - OntologyNode:
+                                            examples:
+                                                - conflict
+                                                - war
+                                                - fighting
+                                                - infighting
+                                                - oppression
+                                                - tyranny
+                                                - oppressive regime
+                                                - genocide
+                                                - clash
+                                                - clashes
+                                                - armed clash
+                                                - raid
+                                                - regional turmoil
+                                                - violence
+                                                - outbreak of violence in the region
+                                                - hostility
+                                                - insurgency
+                                                - armed groups
+                                                - armed mobilization
+                                                - sabotage
+                                                - vandalized
+                                                - army mobilization
+                                            name: hostility
+                                            polarity: -1
+                                        - OntologyNode:
+                                            examples:
+                                                - civil unrest
+                                                - social unrest
+                                                - conflict
+                                                - clash
+                                                - destroy
+                                                - protest
+                                                - picket
+                                                - strikes
+                                                - boycott
+                                                - rally
+                                                - turmoil
+                                                - demands
+                                                - riot
+                                            name: demonstrate
+                                            polarity: -1
+                                        - OntologyNode:
+                                            examples:
+                                                - bombard
+                                                - genocide
+                                                - clash
+                                                - attack
+                                                - destroy
+                                                - fight
+                                                - war
+                                                - warlord
+                                                - civil war
+                                                - insurgency
+                                                - revolt
+                                                - rebel
+                                                - uprising
+                                                - militia
+                                                - troops
+                                                - military aggression
+                                                - conflict
+                                                - invaded
+                                                - warfare
+                                                - the outbreak of war
+                                            name: war
+                                            polarity: -1
+                                        - OntologyNode:
+                                            examples:
+                                                - bombard
+                                                - genocide
+                                                - clash
+                                                - attack
+                                                - assault
+                                                - destroyed in combat
+                                                - combat
+                                                - fight
+                                                - battle
+                                                - attacking
+                                                - attacked
+                                                - attacks
+                                                - invaded
+                                                - raiding
+                                                - shoots
+                                                - shooting
+                                                - crossfire
+                                                - invasion
+                                                - massacre
+                                                - psychological warfare
+                                            name: attack
+                                            polarity: -1
+                                        - OntologyNode:
+                                            examples:
+                                                - bombard
+                                                - attack
+                                                - destroy
+                                                - strike
+                                                - bomb
+                                                - bombing
+                                                - explosion
+                                            name: strike
+                                            polarity: -1
+                                        - OntologyNode:
+                                            examples:
+                                                - terrorism
+                                                - insurgency
+                                                - terrorist attack
+                                                - terrorist activity
+                                                - roadside bombing
+                                                - bomb threat
+                                            name: terrorism
+                                            polarity: -1
+                                        - OntologyNode:
+                                            examples:
+                                                - cattle raid
+                                                - livestock raid
+                                                - steal livestock
+                                                - cattle raiding
+                                            name: livestock_raid
+                                            polarity: -1
+                        - OntologyNode:
+                            name: movement
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - transport
+                                        - transporting
+                                        - transportation
+                                        - delivery
+                                    name: transport
+                                    polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - evacuate humanitarian workers
+                                        - evacuated aid personnel
+                                        - evacuating humanitarian
+                                    name: evacuate_humanitarian_workers
+                                    polarity: -1
+                                - OntologyNode:
+                                    examples:
+                                        - animal migration
+                                        - livestock migration
+                                    name: animal_migration
+                                    polarity: 1
+                        - OntologyNode:
+                            name: agriculture
+                            children:
+                                - OntologyNode:
+                                    name: pests
+                                    children:
+                                        - OntologyNode:
+                                            name: locust_related
+                                            children:
+                                                - OntologyNode:
+                                                    examples:
+                                                        - locust eggs
+                                                    name: locust_eggs
+                                                    polarity: -1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - locust breeding
+                                                        - breeding area locust
+                                                    name: locust_breeding
+                                                    polarity: -1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - locust hatching
+                                                    name: locust_hatching
+                                                    polarity: -1
+                                                - OntologyNode:
+                                                    name: solitary
+                                                    children:
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - solitarious hopper
+                                                                - solitary
+                                                                - hopper
+                                                                - immature
+                                                                - instar
+                                                            name: solitary_hopper
+                                                            polarity: -1
+                                                        - OntologyNode:
+                                                            examples:
+                                                                - solitary locust
+                                                                - solitarious adult locust
+                                                                - mature
+                                                            name: solitary_locust
+                                                            polarity: -1
+                                                - OntologyNode:
+                                                    name: gregarious
+                                                    children:
+                                                        - OntologyNode:
+                                                            patterns:
+                                                                - (hopper\s+band)|(bands?\s+of\s+hoppers)
+                                                            examples:
+                                                                - bands of hoppers
+                                                                - locust hopper groups
+                                                                - hopper outbreak upsurge
+                                                                - immature
+                                                            name: hopper_band
+                                                            polarity: -1
+                                                        - OntologyNode:
+                                                            patterns:
+                                                                - (locust\s+swarm)|(swarms?\s+of\s+locust)
+                                                            examples:
+                                                                - swarm
+                                                                - locust swarm
+                                                                - mature maturation
+                                                                - adult
+                                                                - locust infestation
+                                                                - locust outbreak
+                                                            name: locust_swarm
+                                                            polarity: -1
+                                - OntologyNode:
+                                    examples:
+                                        - planting
+                                        - plant
+                                        - planted crops
+                                        - horticulture
+                                    name: planting
+                                    polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - store crops
+                                        - granary
+                                    name: crop_storage
+                                    polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - fertilization
+                                        - biofertilizers
+                                        - fertilizer
+                                        - fertilizers
+                                        - composts
+                                        - guano
+                                        - manure
+                                    name: fertilization
+                                    polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - localized irrigation
+                                        - capillary irrigation
+                                        - sprinkler irrigation
+                                        - furrow irrigation
+                                        - drip fertigation
+                                        - surface irrigation
+                                        - runoff irrigation
+                                        - fertigation
+                                        - wastewater irrigation
+                                        - watering
+                                        - rotation irrigation
+                                        - flood irrigation
+                                        - trickle irrigation
+                                        - centre pivot irrigation
+                                        - subsurface irrigation
+                                        - irrigation system
+                                        - irrigation
+                                    name: irrigation
+                                    polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - pesticide
+                                    name: pesticide
+                                    polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - crop yield
+                                        - harvest
+                                        - harvests
+                                        - harvesting
+                                        - cultivate
+                                        - crop production conditions
+                                        - domestic crop production
+                                        - crop cultivation
+                                        - bamboo production
+                                        - banana production
+                                        - barley production
+                                        - bean production
+                                        - beans production
+                                        - cassava production
+                                        - cereal production
+                                        - cereals production
+                                        - cocoa production
+                                        - coconut production
+                                        - coffee production
+                                        - corn production
+                                        - crop productivity
+                                        - crop performance
+                                        - cultivar production
+                                        - flux production
+                                        - flour production
+                                        - grain production
+                                        - groundnut production
+                                        - groundnuts production
+                                        - legume production
+                                        - maize production
+                                        - mango production
+                                        - meher production
+                                        - millet production
+                                        - oats production
+                                        - oilseed production
+                                        - onion production
+                                        - pepper production
+                                        - potato production
+                                        - rice production
+                                        - rubber production
+                                        - seed production
+                                        - sesame production
+                                        - sorghum production
+                                        - soybean production
+                                        - staple production
+                                        - sugar production
+                                        - tea production
+                                        - tobacco production
+                                        - tomato production
+                                        - tuber production
+                                        - vegetable production
+                                        - wheat production
+                                        - white maize production
+                                        - cropping
+                                        - agricultural production
+                                        - cultivate
+                                    name: crop_production
+                                    polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - livestock
+                                        - cattle
+                                        - cattle herding
+                                        - poultry production
+                                        - domestic animal culture
+                                        - ranching
+                                        - milk production
+                                        - dairy
+                                        - livestock production
+                                        - domestic animals
+                                        - meat production
+                                    name: livestock_production
+                                    polarity: 1
+                                - OntologyNode:
+                                    name: plant_disease
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - pest infestation
+                                                - armyworm
+                                                - fall armyworm
+                                                - insect
+                                                - swarm
+                                                - locust
+                                                - fungus
+                                                - plant nematodes
+                                                - weeds
+                                                - volunteer plants
+                                                - pests
+                                                - mice
+                                                - midges
+                                                - slugs
+                                                - pest
+                                            name: pest_infestation
+                                            polarity: -1
+                                - OntologyNode:
+                                    examples:
+                                        - livestock disease
+                                        - livestock diseases
+                                    name: livestock_disease
+                                    polarity: -1
+                        - OntologyNode:
+                            name: wild_food_sources
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - gather gathering wild foods
+                                        - forage
+                                        - foraging
+                                    name: foraging_wild_foods
+                                    polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - hunting
+                                        - trapping
+                                    name: hunting
+                                    polarity: 1
+                        - OntologyNode:
+                            name: health_and_life
+                            children:
+                                - OntologyNode:
+                                    name: living_condition
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - food safety
+                                            name: food_safety
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - water safety
+                                                - unsafe water
+                                                - lack of clean water
+                                                - unpotable
+                                            name: water_safety
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - unsanitary condition
+                                                - unclean workspaces
+                                                - unclean unsafe living conditions
+                                            name: sanitation_and_hygiene
+                                            polarity: 1
+                                - OntologyNode:
+                                    name: nutrition
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - food intake
+                                            name: food_intake
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - food diversity
+                                                - food variety
+                                                - nutritional variety
+                                                - nutrition
+                                                - nutritional security
+                                            name: food_diversity
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - food preparation
+                                                - cooking
+                                                - meal preparation
+                                            name: food_preparation
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - food preference
+                                                - seed preference
+                                                - dietary preferences
+                                                - food taste choice
+                                            name: food_preference
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - food gap
+                                                - malnutrition
+                                                - undernutrition
+                                                - undernourishment
+                                                - nutritional deficiency
+                                                - vitamin deficiencies
+                                                - food riots
+                                            name: malnutrition
+                                            polarity: -1
+                                        - OntologyNode:
+                                            examples:
+                                                - breast feeding
+                                                - breastfeeding
+                                                - breastfed
+                                            name: breast_feeding
+                                            polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - biometrics
+                                        - fingerprint
+                                        - human features
+                                    name: biometrics
+                                    polarity: 1
+                                - OntologyNode:
+                                    name: disease
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - transmission
+                                                - community spread
+                                                - airborne
+                                                - virus
+                                            name: transmission
+                                            polarity: -1
+                                        - OntologyNode:
+                                            patterns:
+                                                - (COVID|covid)
+                                            examples:
+                                                - covid
+                                                - corona virus
+                                                - coronavirus
+                                            name: covid_virus
+                                            polarity: -1
+                                        - OntologyNode:
+                                            examples:
+                                                - HIV
+                                                - malaria
+                                                - diabetes
+                                                - diarrhea
+                                                - illnesses
+                                                - anemia
+                                                - anaemia
+                                                - cholera
+                                                - hepatitis
+                                                - hiv/aids
+                                                - measles
+                                                - sickness
+                                                - meningitis
+                                                - pneumonia
+                                                - outbreak
+                                                - virus
+                                                - bacteria
+                                                - human disease
+                                                - epidemic
+                                                - fever
+                                                - disease outbreaks
+                                                - preventable diseases
+                                                - infection
+                                                - infectious
+                                            name: human_disease
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - alcohol drug and substance abuse
+                                                - alcohol abuse
+                                                - drug rehabilitation
+                                            name: alcohol_drug_and_substance_abuse
+                                            polarity: -1
+                                - OntologyNode:
+                                    name: treatment
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - disease treatment
+                                                - medication
+                                                - health treatments
+                                                - medical therapy
+                                                - therapeutic treatment
+                                                - cure
+                                                - surgery
+                                            name: health_treatment
+                                            polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - death
+                                        - mortality
+                                        - morbidity
+                                        - deceased
+                                        - loss of life
+                                        - life loss
+                                        - fatality
+                                        - fatal
+                                        - killed
+                                        - suicide
+                                        - deaths
+                                        - murder
+                                    name: death
+                                    polarity: -1
+                                - OntologyNode:
+                                    examples:
+                                        - injury
+                                        - wounds
+                                    name: injury
+                                    polarity: -1
+                                - OntologyNode:
+                                    examples:
+                                        - birth
+                                        - childbirth
+                                        - neonatal
+                                        - born
+                                    name: birth
+                                    polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - basic needs
+                                        - population needs
+                                        - humanitarian needs
+                                    name: basic_needs
+                                    polarity: 1
+                        - OntologyNode:
+                            name: access
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - market access
+                                    name: market_access
+                                    polarity: 1
+                                - OntologyNode:
+                                    name: infrastructure_access
+                                    children:
+                                        - OntologyNode:
+                                            examples:
+                                                - energy
+                                                - electric plant
+                                                - utilities
+                                                - power grid
+                                                - electricity
+                                                - access to electrical services
+                                                - electrical services
+                                            name: electrical
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - waste
+                                                - sewage treatment
+                                                - sewage treatment
+                                                - garbage removal
+                                            name: waste
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - highway access
+                                                - road network access
+                                                - road access
+                                                - accessibility by road
+                                                - able to be reached by road
+                                                - road conditions
+                                            name: road_access
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - bridge
+                                            name: bridge
+                                            polarity: 1
+                                        - OntologyNode:
+                                            examples:
+                                                - construction materials
+                                                - access to construction materials
+                                                - availability of building materials
+                                            name: construction_materials
+                                            polarity: 1
+                                        - OntologyNode:
+                                            name: transportation
+                                            children:
+                                                - OntologyNode:
+                                                    examples:
+                                                        - transit system
+                                                        - public transportation
+                                                        - access to public transit
+                                                        - travel
+                                                        - transit
+                                                        - air services
+                                                    name: travel
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - shipping
+                                                        - freight
+                                                        - cargo
+                                                    name: shipping
+                                                    polarity: 1
+                                        - OntologyNode:
+                                            name: medical
+                                            children:
+                                                - OntologyNode:
+                                                    examples:
+                                                        - ambulances
+                                                        - EMS
+                                                    name: ambulances
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - hospital
+                                                        - clinic
+                                                        - health post
+                                                        - health post
+                                                        - healthcare facility availability
+                                                        - access to hospitals
+                                                    name: medical_facility
+                                                    polarity: 1
+                                                - OntologyNode:
+                                                    examples:
+                                                        - medical workers
+                                                        - health workers
+                                                        - doctors
+                                                        - nurses nursing staff
+                                                        - first responders
+                                                    name: medical_workers
+                                                    polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - water insecurity
+                                        - water shortage
+                                        - water crisis
+                                        - water scarcity
+                                        - lack of access to water
+                                        - water deficits
+                                        - moisture deficits
+                                        - water management
+                                        - administration of water resources
+                                        - water rationing
+                                        - water security
+                                        - availability of water
+                                        - water pumps
+                                        - water pipes
+                                        - cistern
+                                        - potable water
+                                        - access to water
+                                        - drinking water
+                                        - groundwater
+                                        - snow melt
+                                        - water production
+                                        - water trucking
+                                        - salinization
+                                        - wells
+                                        - access to wells
+                                        - capacity of pumps
+                                        - desalination
+                                        - water recycling
+                                        - water access availability
+                                        - water resource
+                                        - water pipes
+                                        - water access
+                                        - water supply
+                                    name: water_access
+                                    polarity: 1
+                        - OntologyNode:
+                            examples:
+                                - trend
+                                - trends
+                                - increased
+                                - decreased
+                                - increase
+                                - decrease
+                                - change
+                                - tendency
+                                - declined
+                                - improved
+                            name: trend
+                            polarity: 1
+                        - OntologyNode:
+                            name: food_security
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - food availability
+                                        - food security
+                                        - good domestic food supply
+                                        - availability of foods
+                                    name: food_availability
+                                    opposite: wm/concept/causal_factor/food_insecurity/food_unavailability
+                                    polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - food production
+                                        - producing food
+                                    name: food_production
+                                    polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - food utilization
+                                        - consumption of enough food
+                                    name: food_utilization
+                                    opposite: wm/concept/causal_factor/food_insecurity/food_nonutilization
+                                    polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - household food storage
+                                    name: household_food_storage
+                                    polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - food access
+                                    name: food_access
+                                    opposite: wm/concept/causal_factor/food_insecurity/food_nonaccess
+                                    polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - food stability
+                                    name: food_stability
+                                    opposite: wm/concept/causal_factor/food_insecurity/food_instability
+                                    polarity: 1
+                        - OntologyNode:
+                            name: food_insecurity
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - food insecurity
+                                        - food scarcity
+                                        - uncertain food sources
+                                        - lack of food
+                                        - food shortage
+                                        - unavailability of food
+                                        - food deficits
+                                        - cereal shortage
+                                    name: food_unavailability
+                                    opposite: wm/concept/causal_factor/food_security/food_availability
+                                    polarity: -1
+                                - OntologyNode:
+                                    examples:
+                                        - food wasting
+                                        - food wastage
+                                        - inadequate food consumption
+                                    name: food_nonutilization
+                                    opposite: wm/concept/causal_factor/food_security/food_utilization
+                                    polarity: -1
+                                - OntologyNode:
+                                    examples:
+                                        - food nonaccess
+                                        - unable to access food supplies
+                                    name: food_nonaccess
+                                    opposite: wm/concept/causal_factor/food_security/food_access
+                                    polarity: -1
+                                - OntologyNode:
+                                    examples:
+                                        - food instability
+                                    name: food_instability
+                                    opposite: wm/concept/causal_factor/food_security/food_stability
+                                    polarity: -1
                 - OntologyNode:
-                  examples:
-                  - water pumps
-                  - treadle
-                  - electric pump
-                  - small scale irrigation pump
-                  name: pumps
-                  polarity: 1
+                    name: entity
+                    children:
+                        - OntologyNode:
+                            examples:
+                                - geographic location
+                            name: geo-location
+                            polarity: 1
+                        - OntologyNode:
+                            examples:
+                                - commission
+                                - workshop
+                                - conference
+                                - partnership
+                                - management
+                                - organization
+                                - programme
+                                - Programme Work
+                                - convention
+                            name: organization
+                            polarity: 1
+                        - OntologyNode:
+                            examples:
+                                - government entity
+                                - program entity
+                            name: government_entity
+                            polarity: 1
+                        - OntologyNode:
+                            name: person_and_group
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - people group
+                                        - people
+                                        - ethnic group
+                                        - population
+                                        - rural
+                                    name: population
+                                    polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - community
+                                        - villages
+                                        - households
+                                        - family
+                                        - families
+                                        - communities
+                                    name: community
+                                    polarity: 1
+                        - OntologyNode:
+                            examples:
+                                - artifact
+                            name: artifact
+                            polarity: 1
                 - OntologyNode:
-                  examples:
-                  - field irrigation
-                  - drip
-                  - sprinklers
-                  name: field_irrigation
-                  polarity: 1
-              - soil_inputs:
-                - OntologyNode:
-                  examples:
-                  - fertilizer
-                  - DAP
-                  - urea
-                  - compost
-                  - manure
-                  - nitrogen
-                  - potassium
-                  - phosphorous
-                  name: fertilizer
-                  polarity: 1
-                - OntologyNode:
-                  examples:
-                  - fertilizer subsidy
-                  - fertilizer voucher
-                  - cash
-                  - price control
-                  - fertilizer coupon
-                  name: fertilizer_subsidy
-                  polarity: 1
-              - weed_pest_control:
-                - OntologyNode:
-                  examples:
-                  - biological pest weed control
-                  - crop rotation
-                  - cover crop
-                  - integrated pest management
-                  - IPM
-                  - companion planting
-                  name: biological
-                  polarity: 1
-                - OntologyNode:
-                  examples:
-                  - chemical pest weed control
-                  - glysophate
-                  - round-up
-                  - dicamba
-                  - DDT
-                  name: chemical
-                  pattern:
-                    - \b(DDT|dicamba|round-up)\b
-                  polarity: 1
-                - OntologyNode:
-                  examples:
-                  - organic pest weed control
-                  - vinegar
-                  - pine oil
-                  - neem oil
-                  name: organic
-                  polarity: 1
-            - post_harvest_inputs:
-              - OntologyNode:
-                examples:
-                - harvest processing equipment
-                - thresher
-                - sorter
-                - washer
-                - drier
-                - x-ray
-                - harvest laser sorter
-                - tarp
-                - harvest drier racks
-                name: processing_equipment
-                polarity: 1
-              - OntologyNode:
-                examples:
-                - harvest packaging
-                - packing lines
-                - branding
-                - packaging material
-                name: packaging
-                polarity: 1
-              - OntologyNode:
-                examples:
-                - warehousing
-                - warehouse receipt system
-                - WRS
-                - storage
-                name: warehousing
-                polarity: 1
-          - information_services:
-            - OntologyNode:
-              examples:
-              - surveillance system
-              - early warning systems
-              - earthquake monitoring
-              - food security monitoring
-              - early warning analysis
-              - famine early warning system
-              - integrated phase classification
-              - IPC
-              - FEWS NET
-              - vulnerability analysis mapping
-              - VAM
-              name: surveillance_system
-              pattern:
-                - \b(IPC|FEWS|VAM)\b
-                - \bearly\s+warning\s+system\b
-              polarity: 1
-            - OntologyNode:
-              examples:
-              - weather monitoring
-              name: weather_monitoring
-              polarity: 1
-            - OntologyNode:
-              examples:
-              - price monitoring
-              name: price_monitoring
-              polarity: 1
-            - human_rights_monitoring:
-              - OntologyNode:
-                examples:
-                - victims
-                - children victims
-                - women victims
-                - refugees
-                - IDP
-                - ethnic minorities
-                name: victims
-                polarity: 1
-              - OntologyNode:
-                examples:
-                - perpetrators
-                - militias
-                - gangs
-                - terrorist groups
-                - non state actors
-                name: perpetrators
-                polarity: 1
-              - OntologyNode:
-                examples:
-                - violations
-                - human rights violations crimes
-                - war crimes
-                - gender based violence
-                - GBV
-                name: violations
-                polarity: 1
-            - statistics:
-              - OntologyNode:
-                examples:
-                - survey
-                - Census
-                - DHS
-                - demographic health surveys
-                - CFSVA
-                - comprehensive food security and vulnerability assessment
-                - AgSS
-                - agricultural sample survey
-                name: national_survey
-                pattern:
-                  - \b(census|AgSS|CFSVA)\b
-                polarity: 1
-          - livelihood_support:
-            - OntologyNode:
-              examples:
-              - food aid
-              - food for work
-              - food for assets
-              - food for training
-              - food vouchers
-              - free food distribution
-              - school feeding
-              name: food_aid
-              polarity: 1
-            - OntologyNode:
-              examples:
-              - nutrition support
-              - food fortification
-              - infant nutrition supplements
-              - infant and young child feeding
-              - micro nutrient supplementation
-              - supplementary feeding
-              name: nutrition_support
-              polarity: 1
-            - OntologyNode:
-              examples:
-              - water
-              - water trucking
-              name: water
-              polarity: 1
-            - OntologyNode:
-              examples:
-              - financial assistance
-              - cash
-              - loans
-              - cash for assets
-              - cash for work
-              - cash transfer
-              - once off cash transfer to facilitate return
-              - grants
-              - remittances
-              name: financial_assistance
-              polarity: 1
-            - OntologyNode:
-              examples:
-              - livelihood assets
-              - fishing nets
-              - boats
-              - farming equipment
-              - bee keeping equipment
-              - improved chicken breed
-              - bicycle
-              - cart
-              name: livelihood_assets
-              polarity: 1
-            - humanitarian_nonfood_items:
-              - OntologyNode:
-                examples:
-                - shelter
-                - tents
-                - shelter kits
-                name: shelter
-                polarity: 1
-          - medical_inputs:
-            - OntologyNode:
-              examples:
-              - vaccine
-              - vaccination
-              - immunization
-              - communicable disease outbreak control
-              - mass vaccination campaign
-              - polio
-              - measles
-              - yellow fever
-              name: vaccine
-              pattern:
-                - \b(immuniz(ations?|e))\b
-              polarity: 1
-            - OntologyNode:
-              examples:
-              - medical treatment
-              - anti retroviral treatment
-              - ART
-              - first aid
-              - basic medical care
-              - childhood essential health services
-              - obstetric and newborn care
-              - operation of mobile clinics
-              - therapeutic feeding
-              - trauma and surgical care
-              - trauma and post operative rehabilitation
-              name: medical_treatment
-              polarity: 1
-            - OntologyNode:
-              examples:
-              - prevention
-              - insecticide treated bednets
-              - malnutrition screening
-              - preventative medicine
-              - well-child visit
-              - well-visit
-              name: prevention
-              polarity: 1
-            - OntologyNode:
-              examples:
-              - psychological
-              - therapy
-              - clinical management of sexual violence
-              - psychological support
-              - therapist counselor
-              name: psychological
-              polarity: 1
-          - OntologyNode:
-            examples:
-            - sanitation and hygiene input
-            - desludging
-            - toilet
-            - septic tank
-            - excreta container
-            - solid waste management
-            - point of use water treatment
-            - piped water supply treatment
-            name: sanitation_and_hygiene_inputs
-            polarity: 1
-        - build: # (construct/repair)
-          - agriculture_infrastructure:
-            - livestock_production_infrastructure:
-              - OntologyNode:
-                examples:
-                - enclosure
-                - barn
-                - pasture
-                - livestock shelter
-                - paddock
-                - chicken coop
-                - coop
-                name: livestock_shelter # enclosure, barn, pasture, etc
-                polarity: 1
-            - crop_production_infrastructure:
-              - OntologyNode:
-                examples:
-                - canal
-                - reservoir
-                - water tower
-                - standpipe
-                - irrigation infrastructure
-                name: irrigation_infrastructure # canal, reservoir, water_tower
-                polarity: 1
-              - OntologyNode:
-                examples:
-                - farmer training center
-                - demonstration plot
-                - extension office
-                name: extension_offices # farmer_training_centers, demonstration plots, etc
-                pattern:
-                  - \bextension\s+offices?
-                polarity: 1
-              - OntologyNode:
-                examples:
-                - nursery
-                - plant nursery
-                - greenhouse
-                - high tunnel
-                - glasshouse
-                - hothouse
-                name: greenhouse # nursery, high_tunnel, etc.
-                polarity: 1
-              - OntologyNode:
-                examples:
-                - on-farm processing facility
-                - silo
-                - tower silo
-                - bunker silo
-                - stave silo
-                - grain silo
-                - grain elevator
-                - cooperative processing
-                - post-harvest
-                name: post_harvest_infrastructure # on-farm_processing_facility, silos, cooperative_processing, storage, etc.
-                pattern:
-                  - \b(tower|bunker|stave|grain)\b\s(silo)
-                polarity: 1
-          - OntologyNode:
-            examples:
-            - factory
-            - industrial park
-            - storage facility
-            - warehouse
-            - processing facility
-            - trade infrastructure
-            name: trade_infrastructure # factory, industrial_park, storage_facilities, warehouse, processing_facilities, etc.
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - community center
-            - classroom
-            - child friendly learning space
-            - school rehabilitation
-            - gender-specific bathrooms
-            - educational infrastructure
-            - school infrastructure
-            name: educational_infrastructure # community_centers, child_friendly_learning_spaces, school_rehabilitation, gender_specific_bathrooms, etc.
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - permanent house
-            - temporary housing
-            - refugee camp
-            - housing provision
-            - leasing or rental services
-            - temporary communal settlement
-            - temporary shelter
-            - portable shelter
-            - shelter
-            name: shelter_housing # permanent_house, temporary_housing, refugee_camp, housing_provision, leasing_or_rental_services, temporary_communal_settlement, etc.
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - sanitation facility
-            - latrine
-            - washing and bathing facility
-            - temporary water points
-            - borehole
-            - permanent water point
-            - borehole repair
-            - WASH infrastructure
-            name: WASH_infrastructure # sanitation facilities, latrines, washing_and_bathing_facilities, temporary_water_points, boreholes, permanent_water_points, borehole_repair, etc.
-            pattern:
-              - \b(WASH)\binfrastructure
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - hospital
-            - mobile clinic
-            - field hospital
-            - triage
-            - emergency treatment center
-            - emergency treatment centre
-            - medical supply chain facility
-            - medical infrastructure
-            name: medical_infrastructure # hospitals, mobile clinics, field_hospitals, emergency treatment centers, medical supply chain facilities, etc.
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - bridge
-            - all weather roads
-            - railway lines
-            - temporary roads
-            - road rehabilitation
-            - road repair
-            - transportation infrastructure
-            name: transportation_infrastructure # bridge, repair, all_weather_roads, railway_lines, temporary_roads, road_rehabilitation
-            pattern:
-              - \b(road|bridge|rail)\s(repair)
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - internet access service
-            - cell-phone tower
-            - cell tower
-            - landline
-            - phone line
-            - telephone pole
-            - telepole
-            - communication infrastructure
-            name: communication_infrastructure # cell-phone_towers, landlines, etc
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - dam
-            - electricity grid
-            - electric grid
-            - power grid
-            - micro-grid
-            - solar panel
-            - wind turbine
-            - wind farm
-            - solar farm
-            - energy infrastructure
-            name: energy_infrastructure # dams, electricity_grids, micro-grids, solar_panels, wind_turbines, wind_farms, solar_farms, etc.
-            polarity: 1
-        - train: # teach, capacity_building, educate, etc
-          - agriculture_training: # extension, capacity_building, training_of_trainers, development_agents (ET specific name for extension workers), extension_workers
-            - production_practices: # Pasture_management, Herd_management, planting_practices, etc.
-              - OntologyNode:
-                examples:
-                - cover cropping
-                - composting
-                - planting practices
-                - training
-                name: planting_training # crop_spacing, planting_times, seed_depth, watering, crop_rotation, cover_cropping, composting, low_till, no_till, perennial_planting, Conservation_agriculture
-                polarity: 1
-              - OntologyNode:
-                examples:
-                - training IPM practices
-                - training integrated pest management
-                - training pest control
-                - weed control
-                name: pest_weed_control # IPM_practices (integrated pest management), etc
-                pattern:
-                  - (\bIPM\b)(\s(practices))?
-                polarity: 1
-              - OntologyNode:
-                examples:
-                - training storage
-                - training processing
-                - training packaging
-                - training safety and hygiene
-                - certifications
-                - ISO
-                - FDA
-                - workplace safety
-                - post-harvest practices
-                name: post_harvest_practices # storage, processing, packaging, safety_and_hygiene, certifications, ISO, FDA, work_place_safety, etc.
-                polarity: 1
-            - OntologyNode:
-              examples:
-              - farmer's almanac
-              - weather information
-              - national weather service meteorological met
-              - agriculture information
-              name: agriculture_information # digital_extension, famers_almanac, mobile_extension, SMS reminders,  Weather_information,  NMA_reports (national met agency), broadcast_weather_reports,
-              pattern:
-                - (\bNM[AS]\b)\s(reports?)
-              polarity: 1
-          - medical_training: # capacity_assessments, community_health_workers (CHWs),
-            - OntologyNode:
-              examples:
-              - medical training
-              - assessment of health facilities
-              - triage of health facilities
-              - evaluation community health workers
-              - CHWs
-              - medical capacity assessment
-              name: assessment_and_triage_of_health_facilities
-              polarity: 1
-            - OntologyNode:
-              examples:
-              - capacity building of medical staff
-              - medical capacity building
-              name: capacity_building_of_medical_staff
-              polarity: 1
-          - OntologyNode:
-            examples:
-            - human rights training
-            name: human_rights_training
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - provision of credit
-            - training for income generation
-            - training credit provision
-            - income generation training
-            - financial management
-            name: financial_management # provision_of_credit_and_training_for_income_generation
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - provision of non-formal education
-            - training community sourced temporary teachers
-            - education systems
-            - capacity building of educational staff
-            - training education capacity building
-            name: education_systems #  provision_of_non_formal_education, community_sourced_temporary_teachers
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - behavior change campaign
-            - behaviour change campaign
-            - public health information
-            - hygiene promotion
-            - health information campaign
-            - health promotors
-            - health promotion
-            - public health campaigns
-            name: public_health_campaigns # behaviour change, campaigns, public information, hygiene_promotion, information_campaign, health_promoters,
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - explosive hazards campaign
-            - public safety campaigns
-            name: public_safety_campaigns # explosive_hazards
-            polarity: 1
-          - emergency_preparedness_training: # disaster risk management, resilience building, etc.
-            - OntologyNode:
-              examples:
-              - surveillance system strengthening
-              name: surveillance_system_strengthening
-              polarity: 1
-            - OntologyNode:
-              examples:
-              - SPHERE
-              - core standards
-              - humanitarian charter
-              - humanitarian certifications
-              name: humanitarian_certifications # SPHERE, core_standards, humanitarian_charter, etc.
-              polarity: 1
-        - secure: # protect, stabilize, defend, conserve, neutralize, preserve
-          - OntologyNode:
-            examples:
-            - agricultural assets
-            - cattle raid
-            - supply chain
-            - livelihood protections
-            - defend livelihood
-            - protect livelihood
-            - stabilize livelihood
-            - conserve livelihood
-            - neutralize threat to livelihood
-            - preserve livelihood
-            - secure livelihood
-            name: livelihood_protections #  agricultural assets, cattle_raids, supply chains,
-            polarity: 1
-          - community_security: # policing, governance
-            - OntologyNode:
-              examples:
-              - mine clearance
-              - demining
-              - remove land mines
-              - clear land mines
-              - neutralize land mines
-              name: mine_clearance
-              polarity: 1
-            - OntologyNode:
-              examples:
-              - temporary policing services
-              - temporary police
-              - temporary security services
-              - security escort
-              name: temporary_policing_services
-              polarity: 1
-          - OntologyNode:
-            examples:
-            - conflict mediation
-            - political dialogue
-            - disarmament
-            - demobilization
-            - reintegration
-            - family reunification
-            - rehabilitation of child soldiers
-            - conflict resolution
-            name: conflict_resolution # conflict_mediation, political_dialogue, disarmament, demobilization, reintegration, family_reunification, rehabilitation_of_child_soldier
-            pattern:
-              - peace\s+(building|talks)
-              - conflict\s+resolution
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - water rights
-            - land rights
-            - land deeds
-            - biotechnology
-            - defend natural resources
-            - protect natural resources
-            - stabilize natural resources
-            - conserve natural resources
-            - neutralize threat to natural resources
-            - preserve natural resources
-            - secure natural resources
-            name: secure_natural_resources # Water_rights, Land_rights, land_deeds, Biotechnology, etc.
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - landmark designation conservation
-            - world heritage status site
-            - cultural resources protections
-            name: cultural_resources # landmark_designation, world_heritage_status, etc.
-            pattern:
-              - \bUNESCO\b\sworld\sheritage\ssite
-            polarity: 1
-        - legislate: # regulate, control, tax,  subsidize, penalize, certify, ban, etc.
-          - OntologyNode:
-            examples:
-            - subsidize
-            - subsidies
-            - subsidy
-            name: subsidize
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - tax
-            - taxation
-            - taxes
-            - tax legislation
-            - duty
-            - tariff
-            name: tax
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - control prices
-            - price control
-            - regulate prices
-            - legislate prices
-            - price ceiling
-            - price floor
-            name: control_prices
-            polarity: 1
-      - environmental:
-        - meteorologic:
-          - OntologyNode:
-            examples:
-            - weather
-            - weather systems
-            - rains
-            - rainfall
-            - extreme winds
-            - wet
-            - wetter
-            - climate variability
-            - snow
-            - humid
-            name: weather
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - climate
-            - tropical
-            - equatorial
-            name: climate
-            polarity: 1
-          - precipitation:
-            - OntologyNode:
-              examples:
-              - rainfall
-              - precipitation
-              - rains
-              - rain
-              name: rainfall
-              polarity: 1
-            - OntologyNode:
-              examples:
-              - storm
-              - seasonal monsoon
-              - extreme weather
-              name: storm
-              polarity: 1
-          - OntologyNode:
-            examples:
-            - temperature
-            - cooler
-            - cooling
-            - cold
-            - freezing
-            - heat
-            - heatwave
-            - record highs
-            - warmer
-            - warming
-            name: temperature # temperature of ...
-            polarity: 1
-        - OntologyNode:
-          examples:
-          - environment
-          name: environment
-          polarity: 1
-        - OntologyNode:
-          examples:
-          - climate change mitigation
-          - climate change adaptation
-          name: climate_change_mitigation
-          polarity: 1
-        - OntologyNode:
-          examples:
-          - conservation
-          - sustainable use
-          - biodiversity conservation
-          - forest management
-          - water management
-          - management forest
-          - depleted resources
-          - overexploitation
-          name: resource_management
-          polarity: 1
-        - OntologyNode:
-          examples:
-          - afforestation
-          - agroforestry
-          - forest management
-          - reforestation
-          - forestry
-          - logging
-          name: forestry
-          polarity: 1
-        - natural_resources:
-          - OntologyNode:
-            examples:
-            - water
-            - sea
-            - river
-            - pond
-            - water resource
-            - lake
-            - freshwater
-            - surface water
-            - groundwater
-            - snow melt
-            - water body
-            - reservoir
-            name: water_bodies
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - land availability
-            - availability of cropland
-            name: land_availability
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - fossil fuels
-            - coal
-            - oil
-            - natural gas
-            name: fossil_fuels
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - soil
-            - soil quality
-            - leaching into the soil
-            name: soil
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - pastoral conditions
-            - pasture conditions
-            - rangeland conditions
-            - vegetation conditions
-            - grazing conditions
-            name: pasture
-            polarity: 1
-        - pollution:
-          - OntologyNode:
-            examples:
-            - pollution
-            - greenhouse gas emission
-            - ghg emission
-            name: air_pollution
-            polarity: -1
-          - OntologyNode:
-            examples:
-            - contaminant
-            - contamination
-            - contaminated
-            - soil pollution
-            - soil erosion
-            - pollutants
-            - pollution
-            - leakage
-            - acidification
-            name: land_pollution
-            polarity: -1
-          - OntologyNode:
-            examples:
-            - deforestation
-            - desertification
-            - climate change
-            name: climate_change
-            polarity: -1
-      - crisis_and_disaster:
-        - health:
-          - OntologyNode:
-            examples:
-              - disease outbreak
-              - global pandemic
-              - pandemic
-              - epidemic
-            name: pandemic
-            polarity: -1
-          - mitigation:
-            - OntologyNode:
-              examples:
-                - sanitation
-                - hygiene materials
-                - soap
-                - wash hands
-              name: sanitation
-              polarity: 1
-            - OntologyNode:
-              examples:
-                - contact tracing
-              name: contact_tracing
-              pattern:
-                - (contact tracing)
-              polarity: 1
-            - OntologyNode:
-              examples:
-                - quarantine
-                - shelter in place
-                - isolation
-                - restrict movements
-              name: quarantine
-              pattern:
-                - (quarantin|shelter[- ]in[- ]place)
-              polarity: 1
-            - OntologyNode:
-              examples:
-                - social distancing
-              name: social_distancing
-              pattern:
-                - (social distancing)
-              polarity: 1
-            - OntologyNode:
-              examples:
-                - masks
-                - mask requirements
-                - wearing face coverings
-              name: masks
-              polarity: 1
-        - OntologyNode:
-          examples:
-          - famine
-          - hunger
-          - starvation
-          - inadequate food consumption
-          - food deprivation
-          - severe food insecurity
-          - global acute malnutrition
-          - acute malnutrition
-          name: famine
-          polarity: -1
-        - OntologyNode:
-          examples:
-          - crisis
-          - crises
-          - emergency
-          - disasters
-          - catastrophe
-          name: crisis
-          polarity: -1
-        - economic:
-          - OntologyNode:
-            examples:
-            - economic crisis
-            - financial crisis
-            - economic volatility
-            name: economic_crisis
-            polarity: -1
-        - environmental_disasters:
-          - OntologyNode:
-            examples:
-            - crop failure
-            - loss of crops
-            - decimated crop yields
-            name: crop_failure
-            polarity: -1
-          - OntologyNode:
-            examples:
-            - insect infestation
-            name: insect_infestation
-            polarity: -1
-          - natural_disaster:
-            - OntologyNode:
-              examples:
-              - flood
-              - floods
-              - flooding
-              - flash flood
-              name: flooding
-              polarity: -1
-            - OntologyNode:
-              examples:
-              - avalanche
-              name: avalanche
-              polarity: -1
-            - OntologyNode:
-              examples:
-              - wildfire
-              name: wildfire
-              polarity: -1
-            - OntologyNode:
-              examples:
-              - volcanic eruption
-              name: volcanic_eruption
-              polarity: -1
-            - OntologyNode:
-              examples:
-              - drought
-              - droughts
-              - low rainfall
-              name: drought
-              polarity: -1
-            - OntologyNode:
-              examples:
-              - earthquake
-              name: earthquake
-              polarity: -1
-          - weather_issue:
-            - OntologyNode:
-              examples:
-              - cold temperature
-              - frigid conditions
-              - blizzard
-              - arctic winds
-              - winter emergency
-              - state of emergency due to cold weather
-              name: cold_temperature
-              polarity: -1
-          - OntologyNode:
-            examples:
-            - fire
-            - blaze
-            - wildfires
-            - burned
-            name: fire # what is on fire?
-            polarity: -1
-      - economic_and_commerce:
-        - OntologyNode:
-          examples:
-          - poverty
-          - poor
-          name: poverty
-          polarity: -1
-        - economic_activity:
-          - livelihood:
-            #examples:
-            #- livelihood
-            #- livelihood activities
-            #- workplace
-            #- work
-            #- job
-            #- career
-            #- opportunity
-            #- employment
-            #- agribusiness
-            #- pastoralist livelihood
-            #- find work
-            #- wages
-            #- high unemployment
-            #- underemployment
-            - OntologyNode:
-              examples:
-              - farming
-              name: farming
-              polarity: 1
-          - OntologyNode:
-            examples:
-            - currency
-            - dollar
-            - pound
-            - cash
-            - money
-            - hard currency
-            - foreign exchange
-            name: currency
-            polarity: 1
-          - cross_border_trade:
-            - import:
-              - OntologyNode:
-                examples:
-                - imported foods
-                - crop imports
-                - food import
-                - food imports
-                - imports of staples
-                - international crop trade
-                - food trade between countries
-                name: food_import # thing imported
-                polarity: 1
-            - export:
-              - OntologyNode:
-                examples:
-                - crop exports
-                - food exports
-                - exported foods
-                - food exports
-                - exports of staples
-                - international crop trade
-                - food trade between countries
-                name: food_export # thing exported
-                polarity: 1
-          - market:
-            - OntologyNode:
-              examples:
-              - labor market
-              - labour market
-              - employees
-              - hiring
-              - employment
-              - recruit
-              - find work
-              name: labor_market
-              polarity: 1
-            - OntologyNode:
-              examples:
-              - fuel
-              - biofuel
-              - petroleum production
-              - gas
-              - oil
-              - demand for oil
-              - oil markets
-              - crude
-              - crude market
-              - petrol
-              - diesel
-              - oil production
-              name: fuel
-              polarity: 1
-            - price_or_cost:
-              - OntologyNode:
-                examples:
-                - food price
-                - food prices
-                - crop price
-                - food cost
-                - staple prices
-                - staple food price
-                - cost of food
-                - wheat prices
-                - cost of maize
-                - rising cost of food
-                - price of soy
-                - rice prices
-                - high food prices
-                - grain cost
-                name: food_price
-                polarity: 1
-              - OntologyNode:
-                examples:
-                - bamboo prices
-                - banana prices
-                - barley prices
-                - bean prices
-                - beans prices
-                - cassava prices
-                - cereal prices
-                - cereals prices
-                - cocoa prices
-                - coconut prices
-                - coffee prices
-                - corn prices
-                - crop prices
-                - cultivar prices
-                - flux prices
-                - flour prices
-                - grain prices
-                - groundnut prices
-                - groundnuts prices
-                - legume prices
-                - maize prices
-                - mango prices
-                - meher prices
-                - millet prices
-                - oats prices
-                - oilseed prices
-                - onion prices
-                - pepper prices
-                - potato prices
-                - rice prices
-                - rubber prices
-                - seed prices
-                - sesame prices
-                - sorghum prices
-                - soybean prices
-                - staple prices
-                - sugar prices
-                - tea prices
-                - tobacco prices
-                - tomato prices
-                - tuber prices
-                - vegetable prices
-                - wheat prices
-                - white maize prices
-                name: crop_price
-                polarity: 1
-              - OntologyNode:
-                examples:
-                - oil price # should we have these?
-                - cost of crude oil
-                name: oil_price
-                polarity: 1
-              - OntologyNode:
-                examples:
-                - cost of living
-                - rent
-                - housing cost
-                name: cost_of_living
-                polarity: 1
-              - OntologyNode:
-                examples:
-                - cost of transportation
-                - rising transit costs
-                - fuel prices
-                name: cost_of_transportation
-                polarity: 1
-            - revenue:
-              #examples:
-              #- livelihood
-              #- net profit
-              #- profit
-              #- earning
-              #- earnings
-              #- revenue
-              #- investment
-              #- repaying
-              #- fee
-              #- dividend
-              #- disbursements
-              - OntologyNode:
-                examples:
-                - household income
-                - take home pay
-                - wages
-                - compensation
-                name: household_income
-                polarity: 1
-              - OntologyNode:
-                examples:
-                - farmer income
-                - seasonal income
-                name: farmer_income
-                polarity: 1
-            - OntologyNode:
-              examples:
-              - budget
-              - budgetary constraints
-              - fiscal deficits
-              name: budget
-              polarity: 1
-            - OntologyNode:
-              examples:
-              - assets
-              - property
-              - land assets
-              name: assets
-              polarity: 1
-            - supply:
-              - OntologyNode:
-                examples:
-                - food supply
-                - market supply of crops
-                - maize supply
-                - domestic food supplies
-                - supplies of food crops
-                name: food_supply
-                polarity: 1
-            - demand:
-              - OntologyNode:
-                examples:
-                - food demand
-                - maize demand
-                - market demand for crops
-                name: food_demand
-                polarity: 1
-            - transaction:
-              - OntologyNode:
-                examples:
-                - oil transaction
-                - purchasing crude oil
-                - oil trade
-                - selling barrels
-                name: oil_transaction
-                polarity: 1
-              - OntologyNode:
-                examples:
-                - purchasing food
-                name: food_purchase
-                polarity: 1
-            - OntologyNode:
-              examples:
-              - depreciation
-              - depreciating
-              - devaluation
-              - decreased in value
-              name: depreciation
-              polarity: -1
-            - OntologyNode:
-              examples:
-              - inflation
-              - hyperinflation
-              - inflationary pressure
-              name: inflation
-              polarity: -1
-            - OntologyNode:
-              examples:
-              - currency devaluation
-              - devaluate
-              - currency devalued
-              name: currency_devaluation
-              polarity: -1
-            - OntologyNode:
-              examples:
-              - food stocks
-              - food reserves
-              - grain storage
-              - food reserves
-              - grain reserves
-              - food emergency reserves
-              - price stabilization reserves
-              name: food_stocks
-              polarity: 1
-          - OntologyNode:
-            examples:
-            - business competition
-            - competitors
-            - industry rivalry
-            - competition for resources
-            - economic competition
-            - market pressure
-            name: competition # between? about?
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - development
-            - economic development
-            - rural development
-            - agricultural development
-            name: development # being developed
-            polarity: 1
-      - research_development:
-        - OntologyNode:
-          examples:
-          - novel new technology
-          - research innovation
-          - breakthrough technology
-          name: technology_and_innovation
-          polarity: 1
-      - social_and_political:
-        - communication:
-          - OntologyNode:
-            examples:
-            - planning
-            - develop plans
-            name: planning
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - discussion
-            - debate
-            - communication
-            - discourse
-            - dialogue
-            name: discussion_debate
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - collaboration
-            - collaborate
-            - partnership
-            - partner
-            - pact
-            - consortium
-            name: collaboration
-            polarity: 1
-        - OntologyNode:
-          examples:
-          - basic services
-          - primary services
-          - essential services
-          name: basic_services
-          polarity: 1
-        - population_group:
-          - OntologyNode:
-            examples:
-            - population density
-            - local population
-            name: population_density
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - depopulation
-            - de-population
-            name: de-population
-            polarity: -1
-          - OntologyNode:
-            examples:
-            - overcrowding
-            - over-crowding
-            - population density
-            name: overcrowding
-            polarity: -1
-        - educational:
-          - OntologyNode:
-            examples:
-            - literacy
-            - education
-            - school
-            - teacher training
-            - teacher
-            - classroom
-            - school leadership
-            - access to education
-            name: education
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - educational materials
-            - reading materials
-            - teaching aids
-            - classroom supplies
-            - school supplies
-            name: educational_materials
-            polarity: 1
-        - government:
-          - OntologyNode:
-            examples:
-            - census
-            - survey
-            name: census
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - regulation
-            - governance
-            - enforcement
-            - law
-            - policy
-            - legislation
-            - policies
-            name: regulation # topic
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - tax duty
-            - taxes
-            - taxation
-            - tariffs
-            - tariff
-            - export taxes
-            - excise
-            name: tax_duty
-            polarity: 1
-        - political:
-          - OntologyNode:
-            examples:
-            - political instability
-            - power struggle
-            - regime breakdown
-            - political violence
-            - unrest
-            name: political_instability
-            polarity: -1
-          - OntologyNode:
-            examples:
-            - corruption
-            - fraud
-            - fraudulency
-            - bribery
-            - extortion
-            - nepotism
-            name: corruption
-            polarity: -1
-          - OntologyNode:
-            examples:
-            - independence
-            - self-rule
-            - political independence
-            name: independence
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - sanction
-            - economic sanctions
-            - diplomatic sanctions
-            - sanctioned
-            name: sanction
-            polarity: -1
-        - migration:
-          - OntologyNode:
-            examples:
-            - migration
-            - displacement
-            - displaced
-            - evicted
-            - flee
-            - fled
-            - relocate
-            - migrate
-            - refugee migration
-            - residence move
-            - movement trends
-            - refugee
-            - refugees
-            - refugee population
-            - IDPs
-            - human displacement
-            name: human_migration
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - hosting IDPs
-            - internal displacement
-            - host internally displaced persons
-            - host refugees
-            - host migrants
-            name: hosting_idps
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - emigration
-            - leaving
-            - leave the country
-            - flight
-            - flee
-            - fleeing
-            - fled
-            - refugees from countries
-            name: emigration
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - arrival
-            - arrivals
-            - arrive in the country
-            - immigration
-            - immigrate
-            - choose to come
-            - influx
-            - new refugees
-            name: immigration
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - returnee
-            - return to homeland
-            - returned to countries
-            name: migration_returnees
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - seasonal migration
-            - cyclic migration
-            - migrant
-            name: seasonal_migration
-            polarity: 1
-        - threat:
-          - OntologyNode:
-            examples:
-            - exploitation
-            name: exploitation
-            polarity: -1
-          - OntologyNode:
-            examples:
-            - insecurity
-            - instability
-            - physical insecurity
-            - perceived security
-            - dangerous
-            name: physical_insecurity
-            polarity: -1
-          - OntologyNode:
-            examples:
-            - disarmament
-            name: disarmament
-            polarity: 1
-        - criminal:
-          - OntologyNode:
-            examples:
-            - crime
-            - crimes
-            - criminal
-            - bribery
-            - cybercrimes
-            - murdered
-            - sexual abuse
-            - assault
-            - stealing
-            - stolen
-            - looted
-            - looting
-            - theft
-            - riots
-            - violations
-            - violent crime
-            - lawlessness
-            - illegal
-            name: crime
-            polarity: -1
-          - OntologyNode:
-            examples:
-            - child abductions
-            - abduction
-            - kidnapping
-            - forced recruitment
-            - abducted
-            - kidnapped
-            name: abduction
-            polarity: -1
-        - conflict:
-          - OntologyNode:
-            examples:
-            - political tension
-            - political tensions
-            - adversity
-            - political instability
-            - stress
-            - distress
-            - challenge
-            - hardship
-            - burden
-            - threatening
-            name: tension
-            polarity: -1
-          - OntologyNode:
-            examples:
-            - conflict
-            - war
-            - fighting
-            - infighting
-            - oppression
-            - tyranny
-            - oppressive regime
-            - genocide
-            - clash
-            - clashes
-            - armed clash
-            - raid
-            - regional turmoil
-            - violence
-            - outbreak of violence in the region
-            - hostility
-            - insurgency
-            - armed groups
-            - armed mobilization
-            - sabotage
-            - vandalized
-            - army mobilization
-            name: hostility
-            polarity: -1
-          - OntologyNode:
-            examples:
-            - civil unrest
-            - social unrest
-            - conflict
-            - clash
-            - destroy
-            - protest
-            - picket
-            - strikes
-            - boycott
-            - rally
-            - turmoil
-            - demands
-            - riot
-            name: demonstrate
-            polarity: -1
-          - OntologyNode:
-            examples:
-            - bombard
-            - genocide
-            - clash
-            - attack
-            - destroy
-            - fight
-            - war
-            - warlord
-            - civil war
-            - insurgency
-            - revolt
-            - rebel
-            - uprising
-            - militia
-            - troops
-            - military aggression
-            - conflict
-            - invaded
-            - warfare
-            - the outbreak of war
-            name: war
-            polarity: -1
-          - OntologyNode:
-            examples:
-            - bombard
-            - genocide
-            - clash
-            - attack
-            - assault
-            - destroyed in combat
-            - combat
-            - fight
-            - battle
-            - attacking
-            - attacked
-            - attacks
-            - invaded
-            - raiding
-            - shoots
-            - shooting
-            - crossfire
-            - invasion
-            - massacre
-            - psychological warfare
-            name: attack
-            polarity: -1
-          - OntologyNode:
-            examples:
-            - bombard
-            - attack
-            - destroy
-            - strike
-            - bomb
-            - bombing
-            - explosion
-            name: strike
-            polarity: -1
-          - OntologyNode:
-            examples:
-            - terrorism
-            - insurgency
-            - terrorist attack
-            - terrorist activity
-            - roadside bombing
-            - bomb threat
-            name: terrorism
-            polarity: -1
-          - OntologyNode:
-            examples:
-            - cattle raid
-            - livestock raid
-            - steal livestock
-            - cattle raiding
-            name: livestock_raid
-            polarity: -1
-      - movement:
-        - OntologyNode:
-          examples:
-          - transport
-          - transporting
-          - transportation
-          - delivery
-          name: transport
-          polarity: 1
-        - OntologyNode:
-          examples:
-          - evacuate humanitarian workers
-          - evacuated aid personnel
-          - evacuating humanitarian
-          name: evacuate_humanitarian_workers
-          polarity: -1
-        - OntologyNode:
-          examples:
-          - animal migration
-          - livestock migration
-          name: animal_migration
-          polarity: 1
-      - agriculture:
-        - pests:
-            - locust_related:
-              - OntologyNode:
-                examples:
-                  - locust eggs
-                name: locust_eggs
-                polarity: -1
-              - OntologyNode:
-                examples:
-                  - locust breeding
-                  - breeding area locust
-                name: locust_breeding
-                polarity: -1
-              - OntologyNode:
-                examples:
-                  - locust hatching
-                name: locust_hatching
-                polarity: -1
-              - solitary:
-                - OntologyNode:
-                  examples:
-                    - solitarious hopper
-                    - solitary
-                    - hopper
-                    - immature
-                    - instar
-                  name: solitary_hopper
-                  polarity: -1
-                - OntologyNode:
-                  examples:
-                    - solitary locust
-                    - solitarious adult locust
-                    - mature
-                  name: solitary_locust
-                  polarity: -1
-              - gregarious:
-                - OntologyNode:
-                  examples:
-                    - bands of hoppers
-                    - locust hopper groups
-                    - hopper outbreak upsurge
-                    - immature
-                  name: hopper_band
-                  pattern:
-                    - (hopper\s+band)|(bands?\s+of\s+hoppers)
-                  polarity: -1
-                - OntologyNode:
-                  examples:
-                    - swarm
-                    - locust swarm
-                    - mature maturation
-                    - adult
-                    - locust infestation
-                    - locust outbreak
-                  name: locust_swarm
-                  pattern:
-                    - (locust\s+swarm)|(swarms?\s+of\s+locust)
-                  polarity: -1
-        - OntologyNode:
-          examples:
-          - planting
-          - plant
-          - planted crops
-          - horticulture
-          name: planting
-          polarity: 1
-        - OntologyNode:
-          examples:
-          - store crops
-          - granary
-          name: crop_storage
-          polarity: 1
-        - OntologyNode:
-          examples:
-          - fertilization
-          - biofertilizers
-          - fertilizer
-          - fertilizers
-          - composts
-          - guano
-          - manure
-          name: fertilization
-          polarity: 1
-        - OntologyNode:
-          examples:
-          - localized irrigation
-          - capillary irrigation
-          - sprinkler irrigation
-          - furrow irrigation
-          - drip fertigation
-          - surface irrigation
-          - runoff irrigation
-          - fertigation
-          - wastewater irrigation
-          - watering
-          - rotation irrigation
-          - flood irrigation
-          - trickle irrigation
-          - centre pivot irrigation
-          - subsurface irrigation
-          - irrigation system
-          - irrigation
-          name: irrigation
-          polarity: 1
-        - OntologyNode:
-          examples:
-          - pesticide
-          name: pesticide
-          polarity: 1
-        - OntologyNode:
-          examples:
-          - crop yield
-          - harvest
-          - harvests
-          - harvesting
-          - cultivate
-          - crop production conditions
-          - domestic crop production
-          - crop cultivation
-          - bamboo production
-          - banana production
-          - barley production
-          - bean production
-          - beans production
-          - cassava production
-          - cereal production
-          - cereals production
-          - cocoa production
-          - coconut production
-          - coffee production
-          - corn production
-          - crop productivity
-          - crop performance
-          - cultivar production
-          - flux production
-          - flour production
-          - grain production
-          - groundnut production
-          - groundnuts production
-          - legume production
-          - maize production
-          - mango production
-          - meher production
-          - millet production
-          - oats production
-          - oilseed production
-          - onion production
-          - pepper production
-          - potato production
-          - rice production
-          - rubber production
-          - seed production
-          - sesame production
-          - sorghum production
-          - soybean production
-          - staple production
-          - sugar production
-          - tea production
-          - tobacco production
-          - tomato production
-          - tuber production
-          - vegetable production
-          - wheat production
-          - white maize production
-          - cropping
-          - agricultural production
-          - cultivate
-          name: crop_production
-          polarity: 1
-        - OntologyNode:
-          examples:
-          - livestock
-          - cattle
-          - cattle herding
-          - poultry production
-          - domestic animal culture
-          - ranching
-          - milk production
-          - dairy
-          - livestock production
-          - domestic animals
-          - meat production
-          name: livestock_production
-          polarity: 1
-        - plant_disease:
-          - OntologyNode:
-            examples:
-            - pest infestation
-            - armyworm
-            - fall armyworm
-            - insect
-            - swarm
-            - locust
-            - fungus
-            - plant nematodes
-            - weeds
-            - volunteer plants
-            - pests
-            - mice
-            - midges
-            - slugs
-            - pest
-            name: pest_infestation
-            polarity: -1
-        - OntologyNode:
-          examples:
-          - livestock disease
-          - livestock diseases
-          name: livestock_disease
-          polarity: -1
-      - wild_food_sources:
-        - OntologyNode:
-          examples:
-          - gather gathering wild foods
-          - forage
-          - foraging
-          name: foraging_wild_foods
-          polarity: 1
-        - OntologyNode:
-          examples:
-          - hunting
-          - trapping
-          name: hunting
-          polarity: 1
-      - health_and_life:
-        - living_condition:
-          - OntologyNode:
-            examples:
-            - food safety
-            name: food_safety
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - water safety
-            - unsafe water
-            - lack of clean water
-            - unpotable
-            name: water_safety
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - unsanitary condition
-            - unclean workspaces
-            - unclean unsafe living conditions
-            name: sanitation_and_hygiene
-            polarity: 1
-        - nutrition:
-          - OntologyNode:
-            examples:
-            - food intake
-            name: food_intake
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - food diversity
-            - food variety
-            - nutritional variety
-            - nutrition
-            - nutritional security
-            name: food_diversity
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - food preparation
-            - cooking
-            - meal preparation
-            name: food_preparation
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - food preference
-            - seed preference
-            - dietary preferences
-            - food taste choice
-            name: food_preference
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - food gap
-            - malnutrition
-            - undernutrition
-            - undernourishment
-            - nutritional deficiency
-            - vitamin deficiencies
-            - food riots
-            name: malnutrition
-            polarity: -1
-          - OntologyNode:
-            examples:
-            - breast feeding
-            - breastfeeding
-            - breastfed
-            name: breast_feeding
-            polarity: 1
-        - OntologyNode:
-          examples:
-          - biometrics
-          - fingerprint
-          - human features
-          name: biometrics
-          polarity: 1
-        - disease:
-          - OntologyNode:
-            examples:
-              - transmission
-              - community spread
-              - airborne
-              - virus
-            name: transmission
-            polarity: -1
-          - OntologyNode:
-            examples:
-              - covid
-              - corona virus
-              - coronavirus
-            name: covid_virus
-            pattern:
-              - (COVID|covid)
-            polarity: -1
-          - OntologyNode:
-            examples:
-            - HIV
-            - malaria
-            - diabetes
-            - diarrhea
-            - illnesses
-            - anemia
-            - anaemia
-            - cholera
-            - hepatitis
-            - hiv/aids
-            - measles
-            - sickness
-            - meningitis
-            - pneumonia
-            - outbreak
-            - virus
-            - bacteria
-            - human disease
-            - epidemic
-            - fever
-            - disease outbreaks
-            - preventable diseases
-            - infection
-            - infectious
-            name: human_disease
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - alcohol drug and substance abuse
-            - alcohol abuse
-            - drug rehabilitation
-            name: alcohol_drug_and_substance_abuse
-            polarity: -1
-        - treatment:
-          - OntologyNode:
-            examples:
-            - disease treatment
-            - medication
-            - health treatments
-            - medical therapy
-            - therapeutic treatment
-            - cure
-            - surgery
-            name: health_treatment
-            polarity: 1
-        - OntologyNode:
-          examples:
-          - death
-          - mortality
-          - morbidity
-          - deceased
-          - loss of life
-          - life loss
-          - fatality
-          - fatal
-          - killed
-          - suicide
-          - deaths
-          - murder
-          name: death
-          polarity: -1
-        - OntologyNode:
-          examples:
-          - injury
-          - wounds
-          name: injury
-          polarity: -1
-        - OntologyNode:
-          examples:
-          - birth
-          - childbirth
-          - neonatal
-          - born
-          name: birth
-          polarity: 1
-        - OntologyNode:
-          examples:
-          - basic needs
-          - population needs
-          - humanitarian needs
-          name: basic_needs
-          polarity: 1
-      - access:
-        - OntologyNode:
-          examples:
-          - market access
-          name: market_access
-          polarity: 1
-        - infrastructure_access:
-          - OntologyNode:
-            examples:
-            - energy
-            - electric plant
-            - utilities
-            - power grid
-            - electricity
-            - access to electrical services
-            - electrical services
-            name: electrical
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - waste
-            - sewage treatment
-            - sewage treatment
-            - garbage removal
-            name: waste
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - highway access
-            - road network access
-            - road access
-            - accessibility by road
-            - able to be reached by road
-            - road conditions
-            name: road_access
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - bridge
-            name: bridge
-            polarity: 1
-          - OntologyNode:
-            examples:
-            - construction materials
-            - access to construction materials
-            - availability of building materials
-            name: construction_materials
-            polarity: 1
-          - transportation:
-            - OntologyNode:
-              examples:
-              - transit system
-              - public transportation
-              - access to public transit
-              - travel
-              - transit
-              - air services
-              name: travel
-              polarity: 1
-            - OntologyNode:
-              examples:
-              - shipping
-              - freight
-              - cargo
-              name: shipping
-              polarity: 1
-          - medical:
-            - OntologyNode:
-              examples:
-              - ambulances
-              - EMS
-              name: ambulances
-              polarity: 1
-            - OntologyNode:
-              examples:
-              - hospital
-              - clinic
-              - health post
-              - health post
-              - healthcare facility availability
-              - access to hospitals
-              name: medical_facility
-              polarity: 1
-            - OntologyNode:
-              examples:
-                - medical workers
-                - health workers
-                - doctors
-                - nurses nursing staff
-                - first responders
-              name: medical_workers
-              polarity: 1
-        - OntologyNode:
-          examples:
-          - water insecurity
-          - water shortage
-          - water crisis
-          - water scarcity
-          - lack of access to water
-          - water deficits
-          - moisture deficits
-          - water management
-          - administration of water resources
-          - water rationing
-          - water security
-          - availability of water
-          - water pumps
-          - water pipes
-          - cistern
-          - potable water
-          - access to water
-          - drinking water
-          - groundwater
-          - snow melt
-          - water production
-          - water trucking
-          - salinization
-          - wells
-          - access to wells
-          - capacity of pumps
-          - desalination
-          - water recycling
-          - water access availability
-          - water resource
-          - water pipes
-          - water access
-          - water supply
-          name: water_access
-          polarity: 1
-      - OntologyNode:
-        examples:
-        - trend
-        - trends
-        - increased
-        - decreased
-        - increase
-        - decrease
-        - change
-        - tendency
-        - declined
-        - improved
-        name: trend
-        polarity: 1
-      - food_security:
-        - OntologyNode:
-          examples:
-          - food availability
-          - food security
-          - good domestic food supply
-          - availability of foods
-          name: food_availability
-          opposite: wm/concept/causal_factor/food_insecurity/food_unavailability
-          polarity: 1
-        - OntologyNode:
-          examples:
-          - food production
-          - producing food
-          name: food_production
-          polarity: 1
-        - OntologyNode:
-          examples:
-          - food utilization
-          - consumption of enough food
-          name: food_utilization
-          opposite: wm/concept/causal_factor/food_insecurity/food_nonutilization
-          polarity: 1
-        - OntologyNode:
-          examples:
-          - household food storage
-          name: household_food_storage
-          polarity: 1
-        - OntologyNode:
-          examples:
-          - food access
-          name: food_access
-          opposite: wm/concept/causal_factor/food_insecurity/food_nonaccess
-          polarity: 1
-        - OntologyNode:
-          examples:
-          - food stability
-          name: food_stability
-          opposite: wm/concept/causal_factor/food_insecurity/food_instability
-          polarity: 1
-      - food_insecurity:
-        - OntologyNode:
-          examples:
-          - food insecurity
-          - food scarcity
-          - uncertain food sources
-          - lack of food
-          - food shortage
-          - unavailability of food
-          - food deficits
-          - cereal shortage
-          name: food_unavailability
-          opposite: wm/concept/causal_factor/food_security/food_availability
-          polarity: -1
-        - OntologyNode:
-          examples:
-          - food wasting
-          - food wastage
-          - inadequate food consumption
-          name: food_nonutilization
-          opposite: wm/concept/causal_factor/food_security/food_utilization
-          polarity: -1
-        - OntologyNode:
-          examples:
-          - food nonaccess
-          - unable to access food supplies
-          name: food_nonaccess
-          opposite: wm/concept/causal_factor/food_security/food_access
-          polarity: -1
-        - OntologyNode:
-          examples:
-          - food instability
-          name: food_instability
-          opposite: wm/concept/causal_factor/food_security/food_stability
-          polarity: -1
-    - entity:
-      - OntologyNode:
-        examples:
-        - geographic location
-        name: geo-location
-        polarity: 1
-      - OntologyNode:
-        examples:
-        - commission
-        - workshop
-        - conference
-        - partnership
-        - management
-        - organization
-        - programme
-        - Programme Work
-        - convention
-        name: organization
-        polarity: 1
-      - OntologyNode:
-        examples:
-        - government entity
-        - program entity
-        name: government_entity
-        polarity: 1
-      - person_and_group:
-        - OntologyNode:
-          examples:
-          - people group
-          - people
-          - ethnic group
-          - population
-          - rural
-          name: population
-          polarity: 1
-        - OntologyNode:
-          examples:
-          - community
-          - villages
-          - households
-          - family
-          - families
-          - communities
-          name: community
-          polarity: 1
-      - OntologyNode:
-        examples:
-        - artifact
-        name: artifact
-        polarity: 1
-    - time:
-      - temporal:
-        - OntologyNode:
-          examples:
-          - harvest
-          - lean season
-          - planting season
-          - sowing season
-          name: crop_season
-          polarity: 1
-        - OntologyNode:
-          examples:
-          - summer
-          - winter
-          - fall
-          - spring
-          - dry season
-          - rainy season
-          - monsoon season
-          name: season
-          polarity: 1
+                    name: time
+                    children:
+                        - OntologyNode:
+                            name: temporal
+                            children:
+                                - OntologyNode:
+                                    examples:
+                                        - harvest
+                                        - lean season
+                                        - planting season
+                                        - sowing season
+                                    name: crop_season
+                                    polarity: 1
+                                - OntologyNode:
+                                    examples:
+                                        - summer
+                                        - winter
+                                        - fall
+                                        - spring
+                                        - dry season
+                                        - rainy season
+                                        - monsoon season
+                                    name: season
+                                    polarity: 1
+


### PR DESCRIPTION
Everything is called a node and has an explicit name. Every node can have children, but leaf nodes have none.

Comments still need to be transferred manually. The readme file needs to be updated to match. The format turned out a little wider than I thought it would.
